### PR TITLE
Added rover.svg icon for firmware rover

### DIFF
--- a/data/pictures/aircraft_icons/rover.svg
+++ b/data/pictures/aircraft_icons/rover.svg
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg3767"
+   width="445"
+   height="445"
+   viewBox="0 0 445 445"
+   sodipodi:docname="rover.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata3773">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3771" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1360"
+     inkscape:window-height="731"
+     id="namedview3769"
+     showgrid="false"
+     inkscape:snap-intersection-paths="false"
+     inkscape:zoom="3.4978847"
+     inkscape:cx="249.07393"
+     inkscape:cy="386.24708"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     showguides="false" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="fill"
+     transform="translate(0,5)">
+    <path
+       pprz="ac_color"
+       style="display:inline;opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:0.28993958;stroke-opacity:0.05797101"
+       d="m 204.41094,437.44515 c -16.68754,-0.40151 -19.88285,-0.61249 -24.27438,-4.18254 -2.48267,-2.01825 -6.23471,-7.66883 -6.94742,-11.12893 -0.18067,-0.87707 -1.52632,-15.72684 -2.6787,-32.80376 l -2.09507,-31.04675 -0.002,-91.15153 0.32836,-90.90374 1.70642,-4.6832 c 2.88342,-7.91341 5.053,-14.51012 8.0758,-20.56986 4.39975,-8.82005 8.88189,-15.59764 11.87371,-17.01299 2.97395,-1.40691 10.97934,-3.12302 19.89621,-4.00865 4.98764,-0.49537 35.46623,0.0472 41.61246,0.54732 11.51591,0.93725 16.90147,1.69893 20.77541,5.40445 7.85751,7.51587 13.30427,20.34059 18.23796,36.66274 0.55729,1.84368 1.50498,3.42467 2.25748,5.13701 l -0.53466,93.63199 -0.10355,92.30922 -2.19769,25.90763 c -1.17268,13.82429 -2.43353,26.69844 -2.60661,28.75921 -0.56239,6.69543 -1.42286,10.40573 -4.57827,13.5666 -2.0766,2.08019 -5.66273,3.68248 -8.85533,4.50013 -2.09248,0.5359 -4.06411,1.05837 -22.43931,1.31293 -22.02611,0.30514 -34.22171,0.0709 -47.45166,-0.24728 z m 66.52996,-77.60174 c -0.3976,-0.43853 -1.22834,-1.76239 -2.97765,-3.67599 -1.7493,-1.91361 -3.57056,-3.29729 -3.80667,-3.63614 l -0.66723,-0.84907 -32.72862,-0.0726 -32.73868,-0.28228 -4.36799,4.55881 c -2.53324,2.6439 -3.71366,3.66861 -3.71366,3.75494 0,0.0863 17.63491,-0.27733 40.78336,0.15695 l 40.78336,0.29523 z m 7.82156,-137.96231 c 2.60709,-12.23907 4.97491,-21.95334 4.99617,-22.0947 0.0509,-0.33891 -6.18829,-1.88155 -12.46152,-3.33303 -20.49572,-4.74226 -40.33836,-5.1408 -63.36882,-2.04749 -9.12919,1.22617 -29.98479,4.27885 -30.517,4.74035 -0.18483,0.16029 9.40365,43.59879 9.67955,43.8747 0.0527,0.0527 1.07217,-0.12961 2.58148,-0.60468 7.19085,-2.2634 16.33637,-4.17883 24.88986,-5.12719 5.45891,-0.60524 19.72711,-0.52086 25.51661,0.0229 10.40326,0.97705 22.71318,3.06771 32.35579,5.66608 1.11626,0.30081 1.63839,0.27942 1.72102,0.29382 0.0826,0.0144 1.99979,-9.15167 4.60686,-21.39074 z"
+       id="path6925"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscccssssssscccscccsccccccccsssccccssccssscccc" />
+    <rect
+       id="rect5359-5-3-5-0-6"
+       width="41.161015"
+       height="81.61235"
+       x="119.59071"
+       y="168.34222"
+       style="display:inline;opacity:1;fill:#5e4b45;fill-opacity:1;stroke:#000000;stroke-width:1.33553684;stroke-opacity:0"
+       ry="6.7419291" />
+    <rect
+       id="rect5359-5-3-5-0-6-2"
+       width="41.161015"
+       height="81.61235"
+       x="119.52925"
+       y="337.42499"
+       style="display:inline;opacity:1;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:1.33553684;stroke-opacity:0"
+       ry="6.7419291" />
+    <rect
+       id="rect5359-5-3-5-0-6-8"
+       width="41.161015"
+       height="81.61235"
+       x="300.74564"
+       y="167.8405"
+       style="display:inline;opacity:1;fill:#5e4b45;fill-opacity:1;stroke:#000000;stroke-width:1.33553684;stroke-opacity:0"
+       ry="6.7419291" />
+    <rect
+       id="rect5359-5-3-5-0-6-8-4"
+       width="41.161015"
+       height="81.61235"
+       x="300.5495"
+       y="337.48657"
+       style="display:inline;opacity:1;fill:#5e4b45;fill-opacity:1;stroke:#000000;stroke-width:1.33553684;stroke-opacity:0"
+       ry="6.7419291" />
+    <path
+       pprz="ac_color"
+       style="opacity:1;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:4.19877338;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 230.67876,-0.35752 64.13203,93.1228 -128.26406,-2e-5 z"
+       id="path896"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="point map"
+     style="display:inline;opacity:1"
+     transform="translate(0,-579)">
+    <rect
+       id="rect5359-5-3-5"
+       width="41.161015"
+       height="81.61235"
+       x="119.52925"
+       y="921.42493"
+       style="display:inline;opacity:1;fill:#5e4b45;fill-opacity:1;stroke:#000000;stroke-width:1.33553684;stroke-opacity:1"
+       ry="6.7419291" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 126.59817,969.968 c -1.53944,1.93674 8.93005,-11.29564 13.39507,-16.94345 4.49459,5.5295 15.51057,18.97786 13.48378,16.58858"
+       id="path5377-7-7-8-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:2.96898127;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 168.74258,760.2279 -0.70965,182.38576 4.96769,62.45114 c 0,0 2.12902,13.4838 14.90313,15.6128 12.77409,2.1291 82.32199,0.7097 82.32199,0.7097 0,0 16.32246,0 17.74181,-17.0321 1.41934,-17.03217 4.57228,-56.70927 4.57228,-56.70927 V 761.82467 c -0.004,-3.34463 -13.65023,-37.63405 -20.1854,-42.59011 -5.44648,-4.13041 -29.38417,-5.5963 -40.31473,-5.43838 -11.89693,0.17185 -39.24339,1.44514 -43.13196,5.03691 -4.46504,4.12423 -20.16516,34.38988 -20.16516,41.39481 z"
+       id="path5498-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccscsccsssc" />
+    <path
+       style="opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 177.80729,783.3631 c 31.7568,-6.09274 63.43389,-12.33001 105.63186,0.50182 l -9.28355,43.40692 c -27.9234,-7.22189 -56.4823,-10.31292 -87.06476,-0.25091 z"
+       id="path5734"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 190.21566,943.66602 7.80639,-8.33869 65.4673,0.35488 7.45155,8.1612 z"
+       id="path6541"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 175.13513,824.26363 c -1.18216,-3.97412 6.02456,19.74207 9.04832,29.62882 v 33.86715 27.87433 c -2.83868,9.9354 -9.89519,34.69759 -8.51607,29.80628"
+       id="path6543"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="opacity:1;fill:#ff0000;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 184.20541,887.67772 c -2.90634,-4.85089 -9.84116,-16.38315 -8.71902,-14.55263"
+       id="path6545"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 126.76946,944.20429 c -1.53943,1.93674 8.93006,-11.29563 13.39509,-16.94337 4.49459,5.52949 15.51057,18.97779 13.48377,16.5885"
+       id="path5377-7-7-8-4-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 126.64402,995.7657 c -1.53944,1.93675 8.93005,-11.29563 13.39507,-16.94346 4.49459,5.52951 15.51058,18.97788 13.48378,16.58859"
+       id="path5377-7-7-8-4-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       id="rect5359-5-3-5-0"
+       width="41.161015"
+       height="81.61235"
+       x="119.59071"
+       y="752.34222"
+       style="display:inline;opacity:1;fill:#ff0000;fill-opacity:0;stroke:#000000;stroke-width:1.33553684;stroke-opacity:1"
+       ry="6.7419291" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 126.65963,800.88524 c -1.53944,1.93676 8.93005,-11.29562 13.39507,-16.94344 4.49459,5.52954 15.51058,18.97789 13.48378,16.58859"
+       id="path5377-7-7-8-4-21"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 126.83092,775.12156 c -1.53943,1.93676 8.93006,-11.29561 13.39509,-16.94341 4.4946,5.52952 15.51058,18.97787 13.48378,16.58857"
+       id="path5377-7-7-8-4-2-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 126.70548,826.68297 c -1.53943,1.93675 8.93005,-11.29563 13.39507,-16.94345 4.49459,5.52954 15.51058,18.9779 13.48378,16.5886"
+       id="path5377-7-7-8-4-8-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       id="rect5359-5-3-5-0-1"
+       width="41.161015"
+       height="81.61235"
+       x="300.74564"
+       y="751.84052"
+       style="display:inline;opacity:1;fill:#ff0000;fill-opacity:0;stroke:#000000;stroke-width:1.33553684;stroke-opacity:1"
+       ry="6.7419291" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 307.81453,800.38345 c -1.53943,1.93675 8.93005,-11.29563 13.39507,-16.94344 4.4946,5.52954 15.51058,18.97789 13.48378,16.5886"
+       id="path5377-7-7-8-4-21-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 307.98582,774.61979 c -1.53942,1.93675 8.93006,-11.29563 13.39509,-16.94344 4.49459,5.52954 15.51058,18.97788 13.48378,16.58859"
+       id="path5377-7-7-8-4-2-0-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 307.86038,826.18117 c -1.53944,1.93675 8.93006,-11.29563 13.39507,-16.94343 4.49459,5.52953 15.51058,18.97788 13.48378,16.58859"
+       id="path5377-7-7-8-4-8-5-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       id="rect5359-5-3-5-0-1-5"
+       width="41.161015"
+       height="81.61235"
+       x="300.5495"
+       y="921.48663"
+       style="display:inline;opacity:1;fill:#ff0000;fill-opacity:0;stroke:#000000;stroke-width:1.33553684;stroke-opacity:1"
+       ry="6.7419291" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 307.6184,970.02945 c -1.53944,1.93674 8.93004,-11.29563 13.39507,-16.94345 4.49458,5.52957 15.51058,18.97795 13.48378,16.58867"
+       id="path5377-7-7-8-4-21-1-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 307.78969,944.26575 c -1.53943,1.93681 8.93006,-11.29557 13.39509,-16.94346 4.49459,5.52958 15.51058,18.97795 13.48377,16.58867"
+       id="path5377-7-7-8-4-2-0-0-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 307.66424,995.82715 c -1.53943,1.93683 8.93006,-11.29563 13.39507,-16.94338 4.4946,5.52951 15.51059,18.97788 13.48379,16.58859"
+       id="path5377-7-7-8-4-8-5-8-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:6.53101635;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 210.85641,757.54903 c -3.31015,4.31244 15.35731,-19.80968 19.82235,-25.45749 4.49458,5.52954 22.58473,29.05701 19.32675,24.85224"
+       id="path5377-7-7-8-4-2-0-0-62"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 286.21498,824.76816 c 1.18214,-3.9741 -6.02457,19.74208 -9.04834,29.62882 v 33.86717 27.87437 c 2.8387,9.93539 9.89521,34.69759 8.51609,29.8062"
+       id="path6543-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="display:inline;opacity:1;fill:#ff0000;stroke:#000000;stroke-width:1.33553684px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 277.14469,888.18227 c 2.90634,-4.85089 9.84117,-16.38315 8.71903,-14.55264"
+       id="path6545-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.96898127;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 230.67876,583.64248 -64.13203,93.12278 128.26406,2e-5 -17.37254,-25.22577 z"
+       id="path894"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>


### PR DESCRIPTION
We are working into the port of Paparazzi to rovers, so we decided to design a GCS .svg icon for this firmware. pprz="ac_color" have been added to control the color of the red regions of the icon with the GUI color in Paparazzi Center.