### PR TITLE
[GVF Viewer] New PprzGCS widget to paint GVF parametric trajectories and vector fields

### DIFF
--- a/data/default_layout.xml
+++ b/data/default_layout.xml
@@ -7,6 +7,7 @@
                 <widget name="layers" icon="map_layers_normal.svg"/>
                 <widget name="commands" icon="nav.svg"/>
                 <widget name="gps_classic_viewer" icon="gps.svg"/>
+                <widget name="gvf_viewer" icon="gvf.svg"/>
             </columnLeft>
             <columnRight>
                 <widget name="PFD" icon="pfd.svg"/>

--- a/data/default_layout.xml
+++ b/data/default_layout.xml
@@ -7,7 +7,6 @@
                 <widget name="layers" icon="map_layers_normal.svg"/>
                 <widget name="commands" icon="nav.svg"/>
                 <widget name="gps_classic_viewer" icon="gps.svg"/>
-                <widget name="gvf_viewer" icon="gvf.svg"/>
             </columnLeft>
             <columnRight>
                 <widget name="PFD" icon="pfd.svg"/>

--- a/data/gvf_layout.xml
+++ b/data/gvf_layout.xml
@@ -7,7 +7,7 @@
                 <widget name="layers" icon="map_layers_normal.svg"/>
                 <widget name="commands" icon="nav.svg"/>
                 <widget name="gps_classic_viewer" icon="gps.svg"/>
-                <widget name="gvf_viewer" icon="icon.svg"/>
+                <widget name="gvf_viewer" icon="gvf.svg"/>
             </columnLeft>
             <columnRight>
                 <widget name="PFD" icon="pfd.svg"/>

--- a/data/gvf_layout.xml
+++ b/data/gvf_layout.xml
@@ -1,0 +1,38 @@
+<gcsconf>
+    <layout width="1000" height="800">
+      <columns>
+        <widget name="map2d" size="800">
+          <configure>
+            <columnLeft>
+                <widget name="layers" icon="map_layers_normal.svg"/>
+                <widget name="commands" icon="nav.svg"/>
+                <widget name="gps_classic_viewer" icon="gps.svg"/>
+                <widget name="gvf_viewer" icon="icon.svg"/>
+            </columnLeft>
+            <columnRight>
+                <widget name="PFD" icon="pfd.svg"/>
+                <widget name="settings" icon="settings.svg"/>
+                <widget name="plotter" icon="plotter.svg">
+                    <configure>
+                        <plot name="ground:ENGINE_STATUS:bat" min="9" max="13"/>
+                    </configure>
+                </widget>
+                <widget name="link_status" icon="link_ok.svg"/>
+            </columnRight>
+          </configure>
+        </widget>
+        <rows size="200">
+            <widget name="strips" container="list" alt="commands"/>
+            <widget name="flightplan"/>
+        </rows>
+      </columns>
+    </layout>
+    <speech locale="en_GB">
+        <message name="ground:FLIGHT_PARAM:agl" text="{AC} altitude, {value} meters AGL" timeout="20" expire="10" priority="1"/>
+        <!--message name="ground:FLIGHT_PARAM:airspeed" text="airspeed.. {value} meters per second" timeout="20" expire="10" priority="0"/-->
+        <message name="ground:AP_STATUS:ap_mode" text="mode {value}" timeout="0" expire="20" priority="2" onChange="true"/>
+        <message name="ground:NAV_STATUS:cur_block" text="block {value}" timeout="0" expire="10" priority="0" onChange="true" postprocessing="block"/>
+        
+    </speech>
+    
+</gcsconf>

--- a/data/pictures/gvf.svg
+++ b/data/pictures/gvf.svg
@@ -50,16 +50,16 @@
    guidetolerance="10"
    inkscape:pageopacity="0"
    inkscape:pageshadow="2"
-   inkscape:window-width="1832"
-   inkscape:window-height="906"
+   inkscape:window-width="3752"
+   inkscape:window-height="1930"
    id="namedview143"
    showgrid="false"
    inkscape:snap-text-baseline="true"
    showguides="true"
    inkscape:guide-bbox="true"
    inkscape:zoom="22.627417"
-   inkscape:cx="13.564821"
-   inkscape:cy="43.933928"
+   inkscape:cx="33.876885"
+   inkscape:cy="24.018897"
    inkscape:window-x="88"
    inkscape:window-y="27"
    inkscape:window-maximized="1"
@@ -75,6 +75,14 @@
      position="25.39453,28.367187"
      orientation="1,0"
      id="guide5811"
+     inkscape:locked="false" /><sodipodi:guide
+     position="15.312499,25.539062"
+     orientation="0,1"
+     id="guide860"
+     inkscape:locked="false" /><sodipodi:guide
+     position="33.58203,41.566405"
+     orientation="0,1"
+     id="guide862"
      inkscape:locked="false" /></sodipodi:namedview>
 <g
    id="g110"
@@ -156,24 +164,26 @@
      x="8.0054827"
      y="51.360527"
      style="fill-opacity:1;fill:url(#linearGradient968)" /></text>
+
 <g
    aria-label="GVF"
    transform="matrix(1.0356293,0,0,0.96559648,5.7882618,-2.7876233)"
    style="font-style:normal;font-weight:normal;font-size:16.7840271px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.25880206"
    id="text972"><path
      d="M 6.7028165,19.597455 V 15.377784 H 3.2302689 v -1.746795 h 5.5771216 v 6.74516 q -1.2311751,0.873397 -2.7149006,1.32588 -1.4837237,0.44196 -3.1673833,0.44196 -3.68300435,0 -5.7665331,-2.146664 -2.073006,-2.157189 -2.073006,-5.998037 0,-3.851372 2.073006,-5.9980373 2.08352875,-2.15719 5.7665331,-2.15719 1.5363389,0 2.9148348,0.378826 1.3890186,0.378823 2.5570575,1.115424 v 2.262417 Q 7.2184376,8.6010557 5.8925552,8.0959577 4.5666733,7.5908597 3.1039947,7.5908597 q -2.88326585,0 -4.3354222,1.61 -1.441633,1.6099983 -1.441633,4.7984283 0,3.177906 1.441633,4.787906 1.45215635,1.609999 4.3354222,1.609999 1.1259473,0 2.0098686,-0.189411 0.8839213,-0.199936 1.5889532,-0.610327 z"
-     style="font-size:13.4272213px;stroke-width:2.02039123"
+     style="font-size:13.4272213px;stroke-width:0.3;stroke:#050000;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;fill-opacity:1;fill:#ff0000"
      id="path4777"
      inkscape:connector-curvature="0" /><path
-     style="font-size:13.4272213px;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     style="font-size:13.4272213px;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:0.3;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      d="M 17.009527,3.4923583 V 21.45835 l -3.919994,-6.947464 h -2.218747 l 7.192008,14.888341 7.20109,-14.888341 h -2.209668 l -4.127676,6.93123 V 3.4923583 Z"
      id="path4779"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccccccc" /><path
-     d="m 27.432872,6.1281807 h 9.028625 v 1.788888 h -6.903004 v 4.6300633 h 6.22954 v 1.788888 h -6.22954 v 7.502808 h -2.125621 z"
-     style="font-size:13.4272213px;stroke-width:2.02039123"
+     d="m 27.432872,5.8428199 h 9.028625 v 1.788888 h -6.903004 v 4.6300691 h 6.22954 v 1.788888 h -6.22954 v 8.089394 h -2.125621 z"
+     style="font-size:13.4272213px;fill:#ff0000;fill-opacity:1;stroke:#070000;stroke-width:0.30000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="path4781"
-     inkscape:connector-curvature="0" /><rect
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccc" /><rect
      style="fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect4792"
      width="0"

--- a/data/pictures/gvf.svg
+++ b/data/pictures/gvf.svg
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Capa_1"
+   x="0px"
+   y="0px"
+   width="44.275px"
+   height="44.275px"
+   viewBox="0 0 44.275 44.275"
+   style="enable-background:new 0 0 44.275 44.275;"
+   xml:space="preserve"
+   sodipodi:docname="gvf.svg"
+   enable-background="new"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"><metadata
+   id="metadata147"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs145"><linearGradient
+     inkscape:collect="always"
+     id="linearGradient966"><stop
+       style="stop-color:#000000;stop-opacity:1;"
+       offset="0"
+       id="stop962" /><stop
+       style="stop-color:#000000;stop-opacity:0;"
+       offset="1"
+       id="stop964" /></linearGradient><linearGradient
+     inkscape:collect="always"
+     xlink:href="#linearGradient966"
+     id="linearGradient968"
+     x1="7.9340048"
+     y1="7.8214664"
+     x2="7.6480947"
+     y2="7.9644213"
+     gradientUnits="userSpaceOnUse" /></defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1832"
+   inkscape:window-height="906"
+   id="namedview143"
+   showgrid="false"
+   inkscape:snap-text-baseline="true"
+   showguides="true"
+   inkscape:guide-bbox="true"
+   inkscape:zoom="22.627417"
+   inkscape:cx="13.564821"
+   inkscape:cy="43.933928"
+   inkscape:window-x="88"
+   inkscape:window-y="27"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="text972"><sodipodi:guide
+     position="23.406249,30.95703"
+     orientation="1,0"
+     id="guide4784"
+     inkscape:locked="false" /><sodipodi:guide
+     position="24.49462,44.823939"
+     orientation="1,0"
+     id="guide5809"
+     inkscape:locked="false" /><sodipodi:guide
+     position="25.39453,28.367187"
+     orientation="1,0"
+     id="guide5811"
+     inkscape:locked="false" /></sodipodi:namedview>
+<g
+   id="g110"
+   transform="matrix(0,-0.43620259,0.9244026,0,1.5846877,43.947333)">
+	<path
+   d="m 36.637,33.041 c -1.717,0 -3.254,0.775 -4.285,1.992 l -17.233,-2.98 12.36,-6.751 c 0.9,0.615 1.988,0.976 3.158,0.976 3.098,0 5.617,-2.521 5.617,-5.619 0,-3.097 -2.521,-5.618 -5.617,-5.618 -0.516,0 -1.014,0.076 -1.487,0.206 L 21.55,7.854 C 21.849,7.168 22.017,6.413 22.017,5.618 22.017,2.52 19.496,0 16.398,0 13.3,0 10.779,2.52 10.779,5.617 c 0,3.097 2.521,5.618 5.618,5.618 0.446,0 0.879,-0.058 1.296,-0.157 l 7.725,7.513 c -0.256,0.641 -0.399,1.336 -0.399,2.067 0,0.095 0.01,0.188 0.015,0.281 L 10.538,28.856 C 9.69,28.342 8.7,28.041 7.638,28.041 c -3.098,0 -5.618,2.521 -5.618,5.618 0,3.097 2.521,5.617 5.618,5.617 1.996,0 3.748,-1.049 4.745,-2.623 l 18.78,3.248 c 0.567,2.5 2.805,4.375 5.475,4.375 3.099,0 5.619,-2.521 5.619,-5.617 -10e-4,-3.098 -2.524,-5.618 -5.62,-5.618 z M 33.254,20.659 c 0,1.445 -1.174,2.619 -2.617,2.619 -1.443,0 -2.618,-1.174 -2.618,-2.619 0,-1.444 1.175,-2.618 2.618,-2.618 1.443,0 2.617,1.174 2.617,2.618 z M 13.779,5.617 c 0,-1.444 1.175,-2.618 2.618,-2.618 1.443,0 2.618,1.174 2.618,2.618 0,1.444 -1.175,2.618 -2.618,2.618 -1.443,0 -2.618,-1.174 -2.618,-2.618 z m -6.143,30.66 c -1.443,0 -2.618,-1.174 -2.618,-2.619 0,-1.443 1.175,-2.617 2.618,-2.617 1.443,0 2.618,1.174 2.618,2.617 0,1.446 -1.174,2.619 -2.618,2.619 z m 29.001,5 c -1.443,0 -2.618,-1.174 -2.618,-2.619 0,-1.443 1.175,-2.617 2.618,-2.617 1.443,0 2.617,1.174 2.617,2.617 0,1.446 -1.174,2.619 -2.617,2.619 z"
+   id="path108"
+   inkscape:connector-curvature="0"
+   style="fill:#00b100;fill-opacity:1;stroke:#000000;stroke-width:0.50025952;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</g>
+<g
+   id="g112"
+   style="">
+</g>
+<g
+   id="g114"
+   style="">
+</g>
+<g
+   id="g116"
+   style="">
+</g>
+<g
+   id="g118"
+   style="">
+</g>
+<g
+   id="g120"
+   style="">
+</g>
+<g
+   id="g122"
+   style="">
+</g>
+<g
+   id="g124"
+   style="">
+</g>
+<g
+   id="g126"
+   style="">
+</g>
+<g
+   id="g128"
+   style="">
+</g>
+<g
+   id="g130"
+   style="">
+</g>
+<g
+   id="g132"
+   style="">
+</g>
+<g
+   id="g134"
+   style="">
+</g>
+<g
+   id="g136"
+   style="">
+</g>
+<g
+   id="g138"
+   style="">
+</g>
+<g
+   id="g140"
+   style="">
+</g>
+<text
+   xml:space="preserve"
+   style="font-style:normal;font-weight:normal;font-size:14.66666667px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:url(#linearGradient968);fill-opacity:1;stroke:none;"
+   x="8.0054827"
+   y="15.969904"
+   id="text960"><tspan
+     sodipodi:role="line"
+     id="tspan958"
+     x="8.0054827"
+     y="51.360527"
+     style="fill-opacity:1;fill:url(#linearGradient968)" /></text>
+<g
+   aria-label="GVF"
+   transform="matrix(1.0356293,0,0,0.96559648,5.7882618,-2.7876233)"
+   style="font-style:normal;font-weight:normal;font-size:16.7840271px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.25880206"
+   id="text972"><path
+     d="M 6.7028165,19.597455 V 15.377784 H 3.2302689 v -1.746795 h 5.5771216 v 6.74516 q -1.2311751,0.873397 -2.7149006,1.32588 -1.4837237,0.44196 -3.1673833,0.44196 -3.68300435,0 -5.7665331,-2.146664 -2.073006,-2.157189 -2.073006,-5.998037 0,-3.851372 2.073006,-5.9980373 2.08352875,-2.15719 5.7665331,-2.15719 1.5363389,0 2.9148348,0.378826 1.3890186,0.378823 2.5570575,1.115424 v 2.262417 Q 7.2184376,8.6010557 5.8925552,8.0959577 4.5666733,7.5908597 3.1039947,7.5908597 q -2.88326585,0 -4.3354222,1.61 -1.441633,1.6099983 -1.441633,4.7984283 0,3.177906 1.441633,4.787906 1.45215635,1.609999 4.3354222,1.609999 1.1259473,0 2.0098686,-0.189411 0.8839213,-0.199936 1.5889532,-0.610327 z"
+     style="font-size:13.4272213px;stroke-width:2.02039123"
+     id="path4777"
+     inkscape:connector-curvature="0" /><path
+     style="font-size:13.4272213px;fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:0.30000001;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 17.009527,3.4923583 V 21.45835 l -3.919994,-6.947464 h -2.218747 l 7.192008,14.888341 7.20109,-14.888341 h -2.209668 l -4.127676,6.93123 V 3.4923583 Z"
+     id="path4779"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" /><path
+     d="m 27.432872,6.1281807 h 9.028625 v 1.788888 h -6.903004 v 4.6300633 h 6.22954 v 1.788888 h -6.22954 v 7.502808 h -2.125621 z"
+     style="font-size:13.4272213px;stroke-width:2.02039123"
+     id="path4781"
+     inkscape:connector-curvature="0" /><rect
+     style="fill:#ff0000;fill-opacity:1;stroke:#000000;stroke-width:0.69999999;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect4792"
+     width="0"
+     height="14.563537"
+     x="17.13464"
+     y="4.8060966" /></g></svg>

--- a/src/tools/dispatcher_ui.h
+++ b/src/tools/dispatcher_ui.h
@@ -31,7 +31,8 @@ signals:
     //void create_waypoint(Waypoint*);
 
     // GVF viewer signals
-    void gvf_settingUpdated(QString ac_id, bool field_vis, bool traj_vis);
+    void gvf_settingUpdated(QString ac_id, QVector<int> *gvfViewer_config);
+    void gvf_defaultFieldSettings(QString ac_id, int area, int xpts, int ypts);
 
 public slots:
 

--- a/src/tools/dispatcher_ui.h
+++ b/src/tools/dispatcher_ui.h
@@ -33,6 +33,7 @@ signals:
     // GVF viewer signals
     void gvf_settingUpdated(QString ac_id, QVector<int> *gvfViewer_config);
     void gvf_defaultFieldSettings(QString ac_id, int area, int xpts, int ypts);
+    void gvf_zlimits(QString ac_id, float minz, float maxz);
 
 public slots:
 

--- a/src/tools/dispatcher_ui.h
+++ b/src/tools/dispatcher_ui.h
@@ -30,6 +30,9 @@ signals:
     void showHiddenWaypoints(bool show);
     //void create_waypoint(Waypoint*);
 
+    // GVF viewer signals
+    void gvf_settingUpdated(QString ac_id, bool field_vis, bool traj_vis);
+
 public slots:
 
 private:

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/plotter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windindicator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/link_status.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_viewer.cpp
 )
 
 set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/widgets/basics/CMakeLists.txt
+++ b/src/widgets/basics/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/mbpushbutton.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lock_button.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/graphwidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/colorbar.cpp
 )
 
 set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/widgets/basics/colorbar.cpp
+++ b/src/widgets/basics/colorbar.cpp
@@ -1,0 +1,69 @@
+#include "colorbar.h"
+#include <math.h>
+
+ColorBar::ColorBar(qreal bar_height, QWidget *parent) : QWidget(parent),
+    min_color(Qt::red), max_color(Qt::green), 
+    bar_height(bar_height), minSize(QSize(10, 10))
+{
+
+}
+
+void ColorBar::set_zlimits(float minz, float maxz)
+{
+    min_value = round(minz*10)/10;
+    max_value = round(maxz*10)/10;
+}
+
+void ColorBar::paintEvent(QPaintEvent *e) 
+{
+    (void)e;
+    QPainter p(this);
+    
+    // Compute minimum widget size based of text size
+    QFont font = p.font();
+    auto fm = QFontMetricsF(font);
+    auto txt_rect = fm.boundingRect("0000");
+
+    int labelWidth = static_cast<int>(ceil(txt_rect.width()));
+    int labelHeigth = static_cast<int>(ceil(txt_rect.height()));
+
+    int minWidth = labelWidth*2;
+    int minHeigth = labelHeigth + 20;
+    minSize = QSize(minWidth, minHeigth);
+    setMinimumSize(minSize);
+
+    // Draw bar
+    QLinearGradient gradient(0, 0, width(), 0);
+    QGradientStops stops;
+    stops << QGradientStop(0, min_color);
+    stops << QGradientStop(1, max_color);
+    gradient.setStops(stops);
+
+    auto bar = QRect(labelWidth/2, labelHeigth, width() - labelWidth, height() - labelHeigth);
+    p.fillRect(bar, gradient);
+
+    // Draw text labels
+    auto minz_rect = QRect(0, 0, labelWidth, labelHeigth);
+    auto midz_rect = QRect(width()/2 - labelWidth/2, 0, labelWidth, labelHeigth);
+    auto maxz_rect = QRect(width() - labelWidth, 0, labelWidth, labelHeigth);
+    
+    
+    p.setFont(font);
+    p.setPen(Qt::black);
+    p.drawText(minz_rect, Qt::AlignCenter, QString::number(min_value));
+    p.drawText(midz_rect, Qt::AlignCenter, QString::number((min_value + max_value)/2));
+    p.drawText(maxz_rect, Qt::AlignCenter, QString::number(max_value));
+
+    // Draw markers
+    auto minz_marker = QRect(labelWidth/2, labelHeigth - 2, 2, height() - labelHeigth);
+    auto midz_marker = QRect(width()/2 - 1, labelHeigth - 2, 2, height() - labelHeigth);
+    auto maxz_marker = QRect(width() - labelWidth/2 - 2, labelHeigth - 2, 2, height() - labelHeigth);
+    p.fillRect(minz_marker, Qt::black);
+    p.fillRect(midz_marker, Qt::black);
+    p.fillRect(maxz_marker, Qt::black);
+}
+
+QSize ColorBar::minimumSizeHint() const
+{
+    return minSize;
+}

--- a/src/widgets/basics/colorbar.cpp
+++ b/src/widgets/basics/colorbar.cpp
@@ -42,7 +42,7 @@ void ColorBar::paintEvent(QPaintEvent *e)
     auto bar = QRect(labelWidth/2, labelHeigth, width() - labelWidth, height() - labelHeigth);
     p.fillRect(bar, gradient);
 
-    // Draw text labels
+    // Draw text labels (dummy but enough)
     auto minz_rect = QRect(0, 0, labelWidth, labelHeigth);
     auto midz_rect = QRect(width()/2 - labelWidth/2, 0, labelWidth, labelHeigth);
     auto maxz_rect = QRect(width() - labelWidth, 0, labelWidth, labelHeigth);
@@ -54,7 +54,7 @@ void ColorBar::paintEvent(QPaintEvent *e)
     p.drawText(midz_rect, Qt::AlignCenter, QString::number((min_value + max_value)/2));
     p.drawText(maxz_rect, Qt::AlignCenter, QString::number(max_value));
 
-    // Draw markers
+    // Draw markers (dummy but enough)
     auto minz_marker = QRect(labelWidth/2, labelHeigth - 2, 2, height() - labelHeigth);
     auto midz_marker = QRect(width()/2 - 1, labelHeigth - 2, 2, height() - labelHeigth);
     auto maxz_marker = QRect(width() - labelWidth/2 - 2, labelHeigth - 2, 2, height() - labelHeigth);

--- a/src/widgets/basics/colorbar.h
+++ b/src/widgets/basics/colorbar.h
@@ -1,0 +1,32 @@
+#ifndef COLORBAR_H
+#define COLORBAR_H
+
+#include <QWidget>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QFontMetrics>
+
+class ColorBar : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ColorBar(qreal bar_height = 20, QWidget *parent = nullptr);
+
+    void set_zlimits(float minz, float maxz);
+    QSize minimumSizeHint() const override;
+
+protected:
+    void paintEvent(QPaintEvent* e) override;
+
+private:
+    float max_value = 0;
+    float min_value = 0;
+
+    QColor min_color;
+    QColor max_color;
+
+    qreal bar_height;
+    QSize minSize;
+};
+
+#endif //COLORBAR_H

--- a/src/widgets/gvf_viewer.cpp
+++ b/src/widgets/gvf_viewer.cpp
@@ -57,7 +57,7 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
 
     auto alt_layout = new QVBoxLayout();
     auto alt_label = new QLabel("GVF parametric alt (m)", this);
-    auto alt_bar = new ColorBar(20, this); //TODO
+    auto alt_bar = new ColorBar(20, this); 
     alt_layout->addWidget(alt_label, 0, Qt::AlignCenter);
     alt_layout->addWidget(alt_bar);
 

--- a/src/widgets/gvf_viewer.cpp
+++ b/src/widgets/gvf_viewer.cpp
@@ -1,85 +1,65 @@
 #include "gvf_viewer.h"
 #include "dispatcher_ui.h"
 
-// So far this widget looks soo basic but we'll add more GVF setting/info here in a next future :)
-
 GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac_id)
-{
-    auto main_layout = new QVBoxLayout(this);
-    auto settings_layout = new QVBoxLayout();
-    auto hspacer = new QSpacerItem(10,1);
+{   
+    auto grid_layout = new QGridLayout(this);
     
-    auto traj_vis_layout = new QHBoxLayout();
+    // Widgets/items definitions
     auto traj_vis_label= new QLabel("Trajectory", this);
     auto traj_vis_button = new QPushButton(this);
     traj_vis_button->setText(QString("ON"));
-    traj_vis_layout->addWidget(traj_vis_label);
-    traj_vis_layout->addItem(hspacer);
-    traj_vis_layout->addWidget(traj_vis_button);
 
-    auto field_vis_layout = new QHBoxLayout();
     auto field_vis_label= new QLabel("Vector Field", this);
     auto field_vis_button = new QPushButton(this);
     field_vis_button->setText(QString("ON"));
-    field_vis_layout->addWidget(field_vis_label);
-    field_vis_layout->addItem(hspacer);
-    field_vis_layout->addWidget(field_vis_button);
 
-    auto vspacer = new QSpacerItem(1,10);
+    auto vspacer1 = new QSpacerItem(1,10);
 
-    auto mode_layout = new QHBoxLayout();
     auto mode_button = new QPushButton("DEFAULT", this);
-    mode_layout->addWidget(mode_button);
     
-    auto area_layout = new QHBoxLayout();
     auto area_label = new QLabel("Field area", this);
     auto area_spin = new QSpinBox(this); // TODO: Maybe double for small areas??
     area_spin->setMinimum(1);
     area_spin->setMaximum(2147483647);
     area_spin->setValue(2000);
-    area_layout->addWidget(area_label);
-    area_layout->addItem(hspacer);
-    area_layout->addWidget(area_spin);
 
-    auto xpts_layout = new QHBoxLayout();
     auto xpts_label = new QLabel("Field Xpts", this);
     auto xpts_spin = new QSpinBox(this);
     xpts_spin->setMinimum(1);
     xpts_spin->setMaximum(100);
     xpts_spin->setValue(24);
-    xpts_layout->addWidget(xpts_label);
-    xpts_layout->addItem(hspacer);
-    xpts_layout->addWidget(xpts_spin);
 
-    auto ypts_layout = new QHBoxLayout();
     auto ypts_label = new QLabel("Field Ypts", this);
     auto ypts_spin = new QSpinBox(this);
     ypts_spin->setMinimum(1);
     ypts_spin->setMaximum(100);
     ypts_spin->setValue(24);
-    ypts_layout->addWidget(ypts_label);
-    ypts_layout->addItem(hspacer);
-    ypts_layout->addWidget(ypts_spin);
 
-    auto vvspacer = new QSpacerItem(1,30);
+    auto vspacer2 = new QSpacerItem(1,10);
 
-    auto alt_layout = new QVBoxLayout();
     auto alt_label = new QLabel("GVF parametric alt (m)", this);
     auto alt_bar = new ColorBar(20, this); 
-    alt_layout->addWidget(alt_label, 0, Qt::AlignCenter);
-    alt_layout->addWidget(alt_bar);
 
-    settings_layout->addItem(traj_vis_layout);
-    settings_layout->addItem(field_vis_layout);
-    settings_layout->addItem(vspacer);
-    settings_layout->addItem(mode_layout);
-    settings_layout->addItem(area_layout);
-    settings_layout->addItem(xpts_layout);
-    settings_layout->addItem(ypts_layout);
-    settings_layout->addItem(vvspacer);
-    settings_layout->addItem(alt_layout);
-    main_layout->addItem(settings_layout);
+    // Layout construction
+    grid_layout->addWidget(traj_vis_label,   0, 0);
+    grid_layout->addWidget(field_vis_label,  1, 0);
+    grid_layout->addItem(vspacer1,            2, 0, 1, -1);
+    grid_layout->addWidget(mode_button,      3, 0, 1, -1);
+    grid_layout->addWidget(area_label,       4, 0);
+    grid_layout->addWidget(xpts_label,       5, 0);
+    grid_layout->addWidget(ypts_label,       6, 0);
+    grid_layout->addItem(vspacer2,           7, 0, 1, -1);
+    grid_layout->addWidget(alt_label,        8, 0, 1, -1, Qt::AlignCenter);
+    grid_layout->addWidget(alt_bar,          9, 0, 1, -1);
 
+    grid_layout->addWidget(traj_vis_button,  0, 2);
+    grid_layout->addWidget(field_vis_button, 1, 2);
+    grid_layout->addWidget(area_spin,        4, 2);
+    grid_layout->addWidget(xpts_spin,        5, 2);
+    grid_layout->addWidget(ypts_spin,        6, 2);
+
+    // GVF Viewer init
     init();
 
     auto setViewerMode = [=](QString mode) {
@@ -109,11 +89,11 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
         mode_button->setText(viewer_mode);
         area_spin->setSingleStep(gvfV_config[2]/10);
     };
-
+    
     setViewerMode("DEFAULT");
     emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
 
-
+    // Building signals-slots connections
     connect(DispatcherUi::get(), &DispatcherUi::gvf_defaultFieldSettings, this,
             [=](QString sender, int area, int xpts, int ypts) {
                 if(sender == ac_id) {

--- a/src/widgets/gvf_viewer.cpp
+++ b/src/widgets/gvf_viewer.cpp
@@ -1,0 +1,44 @@
+#include "gvf_viewer.h"
+#include "dispatcher_ui.h"
+
+// So far this widget looks soo basic but we'll add more GVF setting/info here in a next future :)
+
+GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac_id)
+{
+    main_layout = new QVBoxLayout(this);
+    settings_layout = new QVBoxLayout();
+    auto hspacer = new QSpacerItem(10,1);
+
+    auto vis_layout = new QHBoxLayout();
+    auto vis_label= new QLabel("Vector Field", this);
+    vis_button = new QPushButton(this);
+    vis_button->setText(QString("ON"));
+    vis_layout->addWidget(vis_label);
+    vis_layout->addItem(hspacer);
+    vis_layout->addWidget(vis_button);
+
+    settings_layout->addItem(vis_layout);
+    main_layout->addItem(settings_layout);
+
+    init();
+}
+
+void GVFViewer::init()
+{   
+    traj_vis = true;
+    field_vis = true;
+    emit DispatcherUi::get()->gvf_settingUpdated(ac_id, traj_vis, field_vis);
+
+    connect(
+        vis_button, &QPushButton::clicked, this,
+        [=]() {
+            if (vis_button->text() == "ON") {
+                emit DispatcherUi::get()->gvf_settingUpdated(ac_id, traj_vis, false);
+                vis_button->setText(QString("OFF"));
+            } else {
+                emit DispatcherUi::get()->gvf_settingUpdated(ac_id, traj_vis, true);
+                vis_button->setText(QString("ON"));
+            }
+        }
+    );
+}

--- a/src/widgets/gvf_viewer.cpp
+++ b/src/widgets/gvf_viewer.cpp
@@ -11,34 +11,153 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
 
     auto vis_layout = new QHBoxLayout();
     auto vis_label= new QLabel("Vector Field", this);
-    vis_button = new QPushButton(this);
+    auto vis_button = new QPushButton(this);
     vis_button->setText(QString("ON"));
     vis_layout->addWidget(vis_label);
     vis_layout->addItem(hspacer);
     vis_layout->addWidget(vis_button);
 
+    auto vspacer = new QSpacerItem(1,10);
+
+    auto mode_layout = new QHBoxLayout();
+    auto mode_button = new QPushButton("DEFAULT", this);
+    mode_layout->addWidget(mode_button);
+    
+    auto area_layout = new QHBoxLayout();
+    auto area_label = new QLabel("Field area", this);
+    auto area_spin = new QSpinBox(this); // TODO: Maybe double for small areas??
+    area_spin->setMinimum(1);
+    area_spin->setMaximum(2147483647);
+    area_spin->setValue(2000);
+    area_layout->addWidget(area_label);
+    area_layout->addItem(hspacer);
+    area_layout->addWidget(area_spin);
+
+    auto xpts_layout = new QHBoxLayout();
+    auto xpts_label = new QLabel("Field Xpts", this);
+    auto xpts_spin = new QSpinBox(this);
+    xpts_spin->setMinimum(1);
+    xpts_spin->setMaximum(100);
+    xpts_spin->setValue(24);
+    xpts_layout->addWidget(xpts_label);
+    xpts_layout->addItem(hspacer);
+    xpts_layout->addWidget(xpts_spin);
+
+    auto ypts_layout = new QHBoxLayout();
+    auto ypts_label = new QLabel("Field Ypts", this);
+    auto ypts_spin = new QSpinBox(this);
+    ypts_spin->setMinimum(1);
+    ypts_spin->setMaximum(100);
+    ypts_spin->setValue(24);
+    ypts_layout->addWidget(ypts_label);
+    ypts_layout->addItem(hspacer);
+    ypts_layout->addWidget(ypts_spin);
+
     settings_layout->addItem(vis_layout);
+    settings_layout->addItem(vspacer);
+    settings_layout->addItem(mode_layout);
+    settings_layout->addItem(area_layout);
+    settings_layout->addItem(xpts_layout);
+    settings_layout->addItem(ypts_layout);
     main_layout->addItem(settings_layout);
 
     init();
-}
 
-void GVFViewer::init()
-{   
-    traj_vis = true;
-    field_vis = true;
-    emit DispatcherUi::get()->gvf_settingUpdated(ac_id, traj_vis, field_vis);
+    auto setViewerMode = [=](QString mode) {
+        if(mode == "DEFAULT") {
+            viewer_mode = "DEFAULT";
+            gvfV_config[2] = gvfV_defField_config[0];
+            gvfV_config[3] = gvfV_defField_config[1];
+            gvfV_config[4] = gvfV_defField_config[2];
+            emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);  
+
+            area_spin->blockSignals(true);
+            ypts_spin->blockSignals(true);
+            xpts_spin->blockSignals(true);
+
+            area_spin->setValue(gvfV_config[2]);
+            xpts_spin->setValue(gvfV_config[3]);
+            xpts_spin->setValue(gvfV_config[4]); 
+
+            area_spin->blockSignals(false);
+            xpts_spin->blockSignals(false);
+            ypts_spin->blockSignals(false);   
+
+        } else if(mode == "CUSTOM") {
+            viewer_mode = "CUSTOM";
+        }
+
+        mode_button->setText(viewer_mode);
+        area_spin->setSingleStep(gvfV_config[2]/10);
+    };
+
+    setViewerMode("DEFAULT");
+    emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
+
+
+    connect(DispatcherUi::get(), &DispatcherUi::gvf_defaultFieldSettings, this,
+            [=](QString sender, int area, int xpts, int ypts) {
+                if(sender == ac_id) {
+                    gvfV_defField_config[0] = area;
+                    gvfV_defField_config[1] = xpts;
+                    gvfV_defField_config[2] = ypts;
+                    setViewerMode(viewer_mode); // if DEFAULT then set def config
+                }
+            });
+
+    connect(
+        mode_button, &QPushButton::clicked, this,
+        [=]() {
+            if (mode_button->text() == "DEFAULT") {
+                setViewerMode("CUSTOM");
+            } else {
+                setViewerMode("DEFAULT");
+            }
+        }
+    );  
 
     connect(
         vis_button, &QPushButton::clicked, this,
         [=]() {
             if (vis_button->text() == "ON") {
-                emit DispatcherUi::get()->gvf_settingUpdated(ac_id, traj_vis, false);
+                gvfV_config[1] = false;
+                emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
                 vis_button->setText(QString("OFF"));
             } else {
-                emit DispatcherUi::get()->gvf_settingUpdated(ac_id, traj_vis, true);
+                gvfV_config[1] = true;
+                emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
                 vis_button->setText(QString("ON"));
             }
         }
     );
+
+    connect(area_spin, qOverload<int>(&QSpinBox::valueChanged), this,
+        [=](int value){
+            gvfV_config[2] = value;
+            setViewerMode("CUSTOM");
+        });
+
+    connect(xpts_spin, qOverload<int>(&QSpinBox::valueChanged), this,
+        [=](int value){
+            gvfV_config[3] = value;
+            setViewerMode("CUSTOM");
+        });
+
+    connect(ypts_spin, qOverload<int>(&QSpinBox::valueChanged), this,
+        [=](int value){
+            gvfV_config[4] = value; 
+            setViewerMode("CUSTOM");
+        });
+}
+
+void GVFViewer::init()
+{   
+    gvfV_config = QVector<int>(5);
+    gvfV_defField_config = QVector<int>(3);
+
+    gvfV_config[0] = true; //traj_vis
+    gvfV_config[1] = true; //field_vis
+    gvfV_defField_config[0] = 2000;  //field_area
+    gvfV_defField_config[1] = 24;    //field_xpoints
+    gvfV_defField_config[2] = 24;    //field_ypoints
 }

--- a/src/widgets/gvf_viewer.cpp
+++ b/src/widgets/gvf_viewer.cpp
@@ -5,8 +5,8 @@
 
 GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac_id)
 {
-    main_layout = new QVBoxLayout(this);
-    settings_layout = new QVBoxLayout();
+    auto main_layout = new QVBoxLayout(this);
+    auto settings_layout = new QVBoxLayout();
     auto hspacer = new QSpacerItem(10,1);
 
     auto vis_layout = new QHBoxLayout();

--- a/src/widgets/gvf_viewer.cpp
+++ b/src/widgets/gvf_viewer.cpp
@@ -9,13 +9,21 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     auto settings_layout = new QVBoxLayout();
     auto hspacer = new QSpacerItem(10,1);
     
-    auto vis_layout = new QHBoxLayout();
-    auto vis_label= new QLabel("Vector Field", this);
-    auto vis_button = new QPushButton(this);
-    vis_button->setText(QString("ON"));
-    vis_layout->addWidget(vis_label);
-    vis_layout->addItem(hspacer);
-    vis_layout->addWidget(vis_button);
+    auto traj_vis_layout = new QHBoxLayout();
+    auto traj_vis_label= new QLabel("Trajectory", this);
+    auto traj_vis_button = new QPushButton(this);
+    traj_vis_button->setText(QString("ON"));
+    traj_vis_layout->addWidget(traj_vis_label);
+    traj_vis_layout->addItem(hspacer);
+    traj_vis_layout->addWidget(traj_vis_button);
+
+    auto field_vis_layout = new QHBoxLayout();
+    auto field_vis_label= new QLabel("Vector Field", this);
+    auto field_vis_button = new QPushButton(this);
+    field_vis_button->setText(QString("ON"));
+    field_vis_layout->addWidget(field_vis_label);
+    field_vis_layout->addItem(hspacer);
+    field_vis_layout->addWidget(field_vis_button);
 
     auto vspacer = new QSpacerItem(1,10);
 
@@ -61,7 +69,8 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     alt_layout->addWidget(alt_label, 0, Qt::AlignCenter);
     alt_layout->addWidget(alt_bar);
 
-    settings_layout->addItem(vis_layout);
+    settings_layout->addItem(traj_vis_layout);
+    settings_layout->addItem(field_vis_layout);
     settings_layout->addItem(vspacer);
     settings_layout->addItem(mode_layout);
     settings_layout->addItem(area_layout);
@@ -135,16 +144,31 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     );  
 
     connect(
-        vis_button, &QPushButton::clicked, this,
+        traj_vis_button, &QPushButton::clicked, this,
         [=]() {
-            if (vis_button->text() == "ON") {
+            if (traj_vis_button->text() == "ON") {
+                gvfV_config[0] = false;
+                emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
+                traj_vis_button->setText(QString("OFF"));
+            } else {
+                gvfV_config[0] = true;
+                emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
+                traj_vis_button->setText(QString("ON"));
+            }
+        }
+    );
+
+    connect(
+        field_vis_button, &QPushButton::clicked, this,
+        [=]() {
+            if (field_vis_button->text() == "ON") {
                 gvfV_config[1] = false;
                 emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
-                vis_button->setText(QString("OFF"));
+                field_vis_button->setText(QString("OFF"));
             } else {
                 gvfV_config[1] = true;
                 emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
-                vis_button->setText(QString("ON"));
+                field_vis_button->setText(QString("ON"));
             }
         }
     );

--- a/src/widgets/gvf_viewer.cpp
+++ b/src/widgets/gvf_viewer.cpp
@@ -8,7 +8,7 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     auto main_layout = new QVBoxLayout(this);
     auto settings_layout = new QVBoxLayout();
     auto hspacer = new QSpacerItem(10,1);
-
+    
     auto vis_layout = new QHBoxLayout();
     auto vis_label= new QLabel("Vector Field", this);
     auto vis_button = new QPushButton(this);
@@ -53,12 +53,22 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     ypts_layout->addItem(hspacer);
     ypts_layout->addWidget(ypts_spin);
 
+    auto vvspacer = new QSpacerItem(1,30);
+
+    auto alt_layout = new QVBoxLayout();
+    auto alt_label = new QLabel("GVF parametric alt (m)", this);
+    auto alt_bar = new ColorBar(20, this); //TODO
+    alt_layout->addWidget(alt_label, 0, Qt::AlignCenter);
+    alt_layout->addWidget(alt_bar);
+
     settings_layout->addItem(vis_layout);
     settings_layout->addItem(vspacer);
     settings_layout->addItem(mode_layout);
     settings_layout->addItem(area_layout);
     settings_layout->addItem(xpts_layout);
     settings_layout->addItem(ypts_layout);
+    settings_layout->addItem(vvspacer);
+    settings_layout->addItem(alt_layout);
     main_layout->addItem(settings_layout);
 
     init();
@@ -66,9 +76,9 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     auto setViewerMode = [=](QString mode) {
         if(mode == "DEFAULT") {
             viewer_mode = "DEFAULT";
-            gvfV_config[2] = gvfV_defField_config[0];
-            gvfV_config[3] = gvfV_defField_config[1];
-            gvfV_config[4] = gvfV_defField_config[2];
+            gvfV_config[2] = gvfV_default_Vfield_config[0];
+            gvfV_config[3] = gvfV_default_Vfield_config[1];
+            gvfV_config[4] = gvfV_default_Vfield_config[2];
             emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);  
 
             area_spin->blockSignals(true);
@@ -98,10 +108,18 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     connect(DispatcherUi::get(), &DispatcherUi::gvf_defaultFieldSettings, this,
             [=](QString sender, int area, int xpts, int ypts) {
                 if(sender == ac_id) {
-                    gvfV_defField_config[0] = area;
-                    gvfV_defField_config[1] = xpts;
-                    gvfV_defField_config[2] = ypts;
+                    gvfV_default_Vfield_config[0] = area;
+                    gvfV_default_Vfield_config[1] = xpts;
+                    gvfV_default_Vfield_config[2] = ypts;
                     setViewerMode(viewer_mode); // if DEFAULT then set def config
+                }
+            });
+
+    connect(DispatcherUi::get(), &DispatcherUi::gvf_zlimits, this,
+            [=](QString sender, float minz, float maxz) {
+                if(sender == ac_id) {
+                    alt_bar->set_zlimits(minz, maxz);
+                    alt_bar->repaint();
                 }
             });
 
@@ -153,11 +171,14 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
 void GVFViewer::init()
 {   
     gvfV_config = QVector<int>(5);
-    gvfV_defField_config = QVector<int>(3);
+    gvfV_default_Vfield_config = QVector<int>(3);
+    gvfV_parametric_config = QVector<float>(2);
 
     gvfV_config[0] = true; //traj_vis
     gvfV_config[1] = true; //field_vis
-    gvfV_defField_config[0] = 2000;  //field_area
-    gvfV_defField_config[1] = 24;    //field_xpoints
-    gvfV_defField_config[2] = 24;    //field_ypoints
+    gvfV_default_Vfield_config[0] = 2000; //field_area
+    gvfV_default_Vfield_config[1] = 24;   //field_xpoints
+    gvfV_default_Vfield_config[2] = 24;   //field_ypoints
+    gvfV_parametric_config[0] = 0; //minz
+    gvfV_parametric_config[1] = 0; //maxz
 }

--- a/src/widgets/gvf_viewer.h
+++ b/src/widgets/gvf_viewer.h
@@ -1,0 +1,29 @@
+#ifndef GVF_SETTINGS_H
+#define GVF_SETTINGS_H
+
+#include <QWidget>
+#include <QtWidgets>
+#include <QBoxLayout>
+#include <QMouseEvent>
+//#include "pprz_dispatcher.h"
+
+class GVFViewer : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit GVFViewer(QString ac_id, QWidget *parent = nullptr);
+
+private:
+    void init();
+
+    QString ac_id;
+    QVBoxLayout* main_layout;
+    QVBoxLayout* settings_layout;
+
+    QPushButton* vis_button;
+
+    bool field_vis;
+    bool traj_vis;
+};
+
+#endif // GVF_SETTINGS_H

--- a/src/widgets/gvf_viewer.h
+++ b/src/widgets/gvf_viewer.h
@@ -17,8 +17,6 @@ private:
     void init();
 
     QString ac_id;
-    QVBoxLayout* main_layout;
-    QVBoxLayout* settings_layout;
 
     QVector<int> gvfV_config;
     QVector<int> gvfV_defField_config;

--- a/src/widgets/gvf_viewer.h
+++ b/src/widgets/gvf_viewer.h
@@ -5,7 +5,7 @@
 #include <QtWidgets>
 #include <QBoxLayout>
 #include <QMouseEvent>
-//#include "pprz_dispatcher.h"
+#include "colorbar.h"
 
 class GVFViewer : public QWidget
 {
@@ -19,7 +19,8 @@ private:
     QString ac_id;
 
     QVector<int> gvfV_config;
-    QVector<int> gvfV_defField_config;
+    QVector<int> gvfV_default_Vfield_config;
+    QVector<float> gvfV_parametric_config;
 
     QString viewer_mode;
 };

--- a/src/widgets/gvf_viewer.h
+++ b/src/widgets/gvf_viewer.h
@@ -20,10 +20,10 @@ private:
     QVBoxLayout* main_layout;
     QVBoxLayout* settings_layout;
 
-    QPushButton* vis_button;
+    QVector<int> gvfV_config;
+    QVector<int> gvfV_defField_config;
 
-    bool field_vis;
-    bool traj_vis;
+    QString viewer_mode;
 };
 
 #endif // GVF_SETTINGS_H

--- a/src/widgets/map/CMakeLists.txt
+++ b/src/widgets/map/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCE
 add_subdirectory(map_items)
 add_subdirectory(graphics_objects)
 add_subdirectory(fpedit_statemachines)
+add_subdirectory(gvf_trajectories)
 
 set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/widgets/map/acitemmanager.cpp
+++ b/src/widgets/map/acitemmanager.cpp
@@ -3,7 +3,7 @@
 ACItemManager::ACItemManager(QString ac_id, WaypointItem* target, AircraftItem* aircraft_item, ArrowItem* arrow, QObject* parent):
     QObject(parent),
     ac_id(ac_id), target(target), aircraft_item(aircraft_item),
-    current_nav_shape(nullptr), max_dist_circle(nullptr), arrow_item(arrow)
+    current_nav_shape(nullptr), max_dist_circle(nullptr), arrow_item(arrow), gvf_trajectory(nullptr)
 {
 
 }
@@ -14,6 +14,10 @@ void ACItemManager::addWaypointItem(WaypointItem* wi) {
 
 void ACItemManager::addPathItem(PathItem* pi) {
     pathItems.append(pi);
+}
+
+void ACItemManager::setCurrentGVF(GVF_trajectory* gvf_traj) {
+    gvf_trajectory = gvf_traj;
 }
 
 void ACItemManager::setCurrentNavShape(MapItem* mi) {
@@ -34,6 +38,13 @@ void ACItemManager::removeItems(MapWidget* map) {
         map->removeItem(wi);
     }
     waypointItems.clear();
+
+    if(gvf_trajectory) {
+        map->removeItem(gvf_trajectory->getTraj());
+        map->removeItem(gvf_trajectory->getVField());
+        gvf_trajectory->purge_trajectory();
+        gvf_trajectory = nullptr;
+    }
 
     if(target) {
         map->removeItem(target);

--- a/src/widgets/map/acitemmanager.cpp
+++ b/src/widgets/map/acitemmanager.cpp
@@ -43,6 +43,8 @@ void ACItemManager::removeItems(MapWidget* map) {
         map->removeItem(gvf_trajectory->getTraj());
         map->removeItem(gvf_trajectory->getVField());
         gvf_trajectory->purge_trajectory();
+
+        delete gvf_trajectory;
         gvf_trajectory = nullptr;
     }
 

--- a/src/widgets/map/acitemmanager.h
+++ b/src/widgets/map/acitemmanager.h
@@ -8,6 +8,7 @@
 #include "mapwidget.h"
 #include "circle_item.h"
 #include "arrow_item.h"
+#include "gvf_trajectory.h"
 
 class ACItemManager: public QObject
 {
@@ -19,7 +20,7 @@ public:
     void addPathItem(PathItem*);
     void setCurrentNavShape(MapItem*);
     void setMaxDistCircle(CircleItem*);
-
+    void setCurrentGVF(GVF_trajectory*);
 
     QList<WaypointItem*> getWaypointsItems() {return waypointItems;}
     WaypointItem* getTarget() {return target;}
@@ -38,6 +39,7 @@ private:
     CircleItem* max_dist_circle;
     ArrowItem* arrow_item;
 
+    GVF_trajectory* gvf_trajectory;
 };
 
 #endif // ACITEMMANAGER_H

--- a/src/widgets/map/graphics_objects/CMakeLists.txt
+++ b/src/widgets/map/graphics_objects/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/graphics_intruder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/graphics_group.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/graphics_icon.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/graphics_quiver.cpp
     
 )
 

--- a/src/widgets/map/graphics_objects/graphics_quiver.cpp
+++ b/src/widgets/map/graphics_objects/graphics_quiver.cpp
@@ -1,6 +1,6 @@
 #include "graphics_quiver.h"
 
-GraphicsQuiver::GraphicsQuiver(float size, PprzPalette palette, QObject *parent) : 
+GraphicsQuiver::GraphicsQuiver(double size, PprzPalette palette, QObject *parent) : 
     GraphicsObject(palette, parent),
     QGraphicsItem (),
     size(size)
@@ -19,10 +19,12 @@ void GraphicsQuiver::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
     (void)widget;
     painter->setPen(QPen(Qt::red, 3));
 
-    painter->drawLine(0, 0, 0, -size);
+    painter->drawLine(0, 0, 0, -size + size/50);
 
     painter->drawLine(0, -size, -size/10, -9*size/10);
     painter->drawLine(0, -size, size/10, -9*size/10);
+    
+    painter->setRenderHint(QPainter::Antialiasing);
 }
 
 void GraphicsQuiver::changeFocus() {

--- a/src/widgets/map/graphics_objects/graphics_quiver.cpp
+++ b/src/widgets/map/graphics_objects/graphics_quiver.cpp
@@ -1,0 +1,30 @@
+#include "graphics_quiver.h"
+
+GraphicsQuiver::GraphicsQuiver(float size, PprzPalette palette, QObject *parent) : 
+    GraphicsObject(palette, parent),
+    QGraphicsItem (),
+    size(size)
+{
+    setFlag(ItemIsMovable);
+}
+
+QRectF GraphicsQuiver::boundingRect() const
+{
+    return QRectF(-size, -size, 2*size, 2*size);
+}
+
+void GraphicsQuiver::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+{
+    (void)option;
+    (void)widget;
+    painter->setPen(QPen(Qt::black, 3));
+
+    painter->drawLine(0, 0, 0, -size);
+
+    painter->drawLine(0, -size, -size/10, -9*size/10);
+    painter->drawLine(0, -size, size/10, -9*size/10);
+}
+
+void GraphicsQuiver::changeFocus() {
+
+}

--- a/src/widgets/map/graphics_objects/graphics_quiver.cpp
+++ b/src/widgets/map/graphics_objects/graphics_quiver.cpp
@@ -4,7 +4,7 @@
 GraphicsQuiver::GraphicsQuiver(PprzPalette palette, float width, QObject *parent) : 
     GraphicsObject(palette, parent),
     QGraphicsItem (),
-    width(width)
+    width(width*2)
 {
 
 }

--- a/src/widgets/map/graphics_objects/graphics_quiver.cpp
+++ b/src/widgets/map/graphics_objects/graphics_quiver.cpp
@@ -17,7 +17,7 @@ void GraphicsQuiver::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 {
     (void)option;
     (void)widget;
-    painter->setPen(QPen(Qt::black, 3));
+    painter->setPen(QPen(Qt::red, 3));
 
     painter->drawLine(0, 0, 0, -size);
 

--- a/src/widgets/map/graphics_objects/graphics_quiver.cpp
+++ b/src/widgets/map/graphics_objects/graphics_quiver.cpp
@@ -1,9 +1,10 @@
 #include "graphics_quiver.h"
 
-GraphicsQuiver::GraphicsQuiver(double size, PprzPalette palette, QObject *parent) : 
+GraphicsQuiver::GraphicsQuiver(double size, PprzPalette palette, QPen pen, QObject *parent) : 
     GraphicsObject(palette, parent),
     QGraphicsItem (),
-    size(size)
+    size(size),
+    pen(pen)
 {
 
 }
@@ -17,7 +18,7 @@ void GraphicsQuiver::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 {
     (void)option;
     (void)widget;
-    painter->setPen(QPen(Qt::red, 0.5));
+    painter->setPen(pen);
 
     painter->drawLine(0, 0, 0, -size);
 

--- a/src/widgets/map/graphics_objects/graphics_quiver.cpp
+++ b/src/widgets/map/graphics_objects/graphics_quiver.cpp
@@ -5,7 +5,7 @@ GraphicsQuiver::GraphicsQuiver(double size, PprzPalette palette, QObject *parent
     QGraphicsItem (),
     size(size)
 {
-    setFlag(ItemIsMovable);
+
 }
 
 QRectF GraphicsQuiver::boundingRect() const
@@ -17,9 +17,9 @@ void GraphicsQuiver::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 {
     (void)option;
     (void)widget;
-    painter->setPen(QPen(Qt::red, 3));
+    painter->setPen(QPen(Qt::red, 0.5));
 
-    painter->drawLine(0, 0, 0, -size + size/50);
+    painter->drawLine(0, 0, 0, -size);
 
     painter->drawLine(0, -size, -size/10, -9*size/10);
     painter->drawLine(0, -size, size/10, -9*size/10);

--- a/src/widgets/map/graphics_objects/graphics_quiver.cpp
+++ b/src/widgets/map/graphics_objects/graphics_quiver.cpp
@@ -4,7 +4,7 @@
 GraphicsQuiver::GraphicsQuiver(PprzPalette palette, float width, QObject *parent) : 
     GraphicsObject(palette, parent),
     QGraphicsItem (),
-    width(width*10)
+    width(width)
 {
 
 }

--- a/src/widgets/map/graphics_objects/graphics_quiver.cpp
+++ b/src/widgets/map/graphics_objects/graphics_quiver.cpp
@@ -1,10 +1,10 @@
 #include "graphics_quiver.h"
+#include <QDebug>
 
-GraphicsQuiver::GraphicsQuiver(double size, PprzPalette palette, QPen pen, QObject *parent) : 
+GraphicsQuiver::GraphicsQuiver(PprzPalette palette, float width, QObject *parent) : 
     GraphicsObject(palette, parent),
     QGraphicsItem (),
-    size(size),
-    pen(pen)
+    width(width*10)
 {
 
 }
@@ -18,16 +18,22 @@ void GraphicsQuiver::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 {
     (void)option;
     (void)widget;
-    painter->setPen(pen);
-
-    painter->drawLine(0, 0, 0, -size);
+    painter->setPen(QPen(palette.getVariant(current_color),width));
+    painter->drawLine(0, 0, 0, -size + size/40);
 
     painter->drawLine(0, -size, -size/10, -9*size/10);
     painter->drawLine(0, -size, size/10, -9*size/10);
-    
-    painter->setRenderHint(QPainter::Antialiasing);
 }
 
 void GraphicsQuiver::changeFocus() {
 
+    if(isHighlighted()) {
+        current_color = COLOR_IDLE;     
+        //setVisible(true);
+    } else {
+        current_color = COLOR_UNFOCUSED;
+        //setVisible(false);
+    }
+
+    update();
 }

--- a/src/widgets/map/graphics_objects/graphics_quiver.h
+++ b/src/widgets/map/graphics_objects/graphics_quiver.h
@@ -3,26 +3,29 @@
 
 #include <QGraphicsItem>
 #include <QPainter>
-#include <QPen>
 #include "graphics_object.h"
+
+#define COLOR_IDLE 0
+#define COLOR_UNFOCUSED 1
 
 class GraphicsQuiver : public GraphicsObject, public QGraphicsItem
 {
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)
 public:
-    explicit GraphicsQuiver(double size, PprzPalette palette, QPen pen, QObject *parent = nullptr);
+    explicit GraphicsQuiver(PprzPalette palette, float width, QObject *parent = nullptr);
 
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
-    double size;
+    float size = 100;
 
 protected:
     virtual void changeFocus() override;
 
 private:
-    QPen pen;
+    float width;
+    uint8_t current_color = COLOR_IDLE;
 };
 
 #endif // GRAPHICSQUIVER_H

--- a/src/widgets/map/graphics_objects/graphics_quiver.h
+++ b/src/widgets/map/graphics_objects/graphics_quiver.h
@@ -18,7 +18,7 @@ public:
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
-    float size = 10;
+    float size = 20;
 
 protected:
     virtual void changeFocus() override;

--- a/src/widgets/map/graphics_objects/graphics_quiver.h
+++ b/src/widgets/map/graphics_objects/graphics_quiver.h
@@ -11,12 +11,12 @@ class GraphicsQuiver : public GraphicsObject, public QGraphicsItem
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)
 public:
-    explicit GraphicsQuiver(float size, PprzPalette palette, QObject *parent = nullptr);
+    explicit GraphicsQuiver(double size, PprzPalette palette, QObject *parent = nullptr);
 
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
-    float size;
+    double size;
 
 protected:
     virtual void changeFocus() override;

--- a/src/widgets/map/graphics_objects/graphics_quiver.h
+++ b/src/widgets/map/graphics_objects/graphics_quiver.h
@@ -11,7 +11,7 @@ class GraphicsQuiver : public GraphicsObject, public QGraphicsItem
     Q_OBJECT
     Q_INTERFACES(QGraphicsItem)
 public:
-    explicit GraphicsQuiver(double size, PprzPalette palette, QObject *parent = nullptr);
+    explicit GraphicsQuiver(double size, PprzPalette palette, QPen pen, QObject *parent = nullptr);
 
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
@@ -20,6 +20,9 @@ public:
 
 protected:
     virtual void changeFocus() override;
+
+private:
+    QPen pen;
 };
 
 #endif // GRAPHICSQUIVER_H

--- a/src/widgets/map/graphics_objects/graphics_quiver.h
+++ b/src/widgets/map/graphics_objects/graphics_quiver.h
@@ -1,0 +1,25 @@
+#ifndef GRAPHICSQUIVER_H
+#define GRAPHICSQUIVER_H
+
+#include <QGraphicsItem>
+#include <QPainter>
+#include <QPen>
+#include "graphics_object.h"
+
+class GraphicsQuiver : public GraphicsObject, public QGraphicsItem
+{
+    Q_OBJECT
+    Q_INTERFACES(QGraphicsItem)
+public:
+    explicit GraphicsQuiver(float size, PprzPalette palette, QObject *parent = nullptr);
+
+    QRectF boundingRect() const override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+
+    float size;
+
+protected:
+    virtual void changeFocus() override;
+};
+
+#endif // GRAPHICSQUIVER_H

--- a/src/widgets/map/graphics_objects/graphics_quiver.h
+++ b/src/widgets/map/graphics_objects/graphics_quiver.h
@@ -18,7 +18,7 @@ public:
     QRectF boundingRect() const override;
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
-    float size = 100;
+    float size = 10;
 
 protected:
     virtual void changeFocus() override;

--- a/src/widgets/map/gvf_trajectories/CMakeLists.txt
+++ b/src/widgets/map/gvf_trajectories/CMakeLists.txt
@@ -5,6 +5,9 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_line.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_ellipse.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_sin.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_trefoil.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_3D_ellipse.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_3D_lissajous.cpp
 )
 
 set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/widgets/map/gvf_trajectories/CMakeLists.txt
+++ b/src/widgets/map/gvf_trajectories/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(SOURCE
     ${SOURCE}
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_trajectory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_line.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_ellipse.cpp
 )
 

--- a/src/widgets/map/gvf_trajectories/CMakeLists.txt
+++ b/src/widgets/map/gvf_trajectories/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+set(SOURCE
+    ${SOURCE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_trajectory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_ellipse.cpp
+)
+
+set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(SOURCE ${SOURCE}  PARENT_SCOPE)
+set(INC_DIRS ${INC_DIRS}  PARENT_SCOPE)
+

--- a/src/widgets/map/gvf_trajectories/CMakeLists.txt
+++ b/src/widgets/map/gvf_trajectories/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_trajectory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_line.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_ellipse.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_traj_sin.cpp
 )
 
 set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.cpp
@@ -1,9 +1,9 @@
 #include "gvf_traj_3D_ellipse.h"
 
-GVF_traj_3D_ellipse::GVF_traj_3D_ellipse(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings) :
+GVF_traj_3D_ellipse::GVF_traj_3D_ellipse(QString id, QList<float> param, QList<float> _phi, QVector<int> *gvf_settings) :
     GVF_trajectory(id, gvf_settings)
 {   
-    set_param(param, _s, phi, _wb);
+    set_param(param, _phi);
     generate_trajectory();
     
 }
@@ -30,7 +30,7 @@ void GVF_traj_3D_ellipse::genVField() {
 }
 
 /////////////// PRIVATE FUNCTIONS ///////////////
-void GVF_traj_3D_ellipse::set_param(QList<float> param, int8_t _s, QList<float> _phi, float _wb) {
+void GVF_traj_3D_ellipse::set_param(QList<float> param, QList<float> _phi) {
 
     if (param.size()>6) { // gvf_parametric_3D_ellipse_wp()
         auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
@@ -46,7 +46,7 @@ void GVF_traj_3D_ellipse::set_param(QList<float> param, int8_t _s, QList<float> 
     zh = param[4];
     alpha = param[5];
 
-    phi = QVector3D(_phi[0], _phi[1], _phi[2]);
+    phi = QVector3D(_phi[0], _phi[1], _phi[2]); //TODO: Display error in GVF viewer??
 }
 
 QVector3D GVF_traj_3D_ellipse::traj_point(float t) {

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.cpp
@@ -8,18 +8,52 @@ GVF_traj_3D_ellipse::GVF_traj_3D_ellipse(QString id, QList<float> param, int8_t 
     
 }
 
-void GVF_traj_3D_ellipse::set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb) {
-
-}
-
 // 3D ellipse trajectory (parametric representation)
 void GVF_traj_3D_ellipse::genTraj() { 
-    QList<QPointF> points;
+    QList<QPointF> xy_points;
+    QList<float> z_points;
 
-    createTrajItem(points);
+    float dt = 0.005*2*M_PI;
+    for (float t = 0; t <= 2*M_PI + dt/2; t+=dt) {
+        auto point = traj_point(t);
+
+        xy_points.append(QPointF(point.x(),point.y()));
+        z_points.append(point.z());
+    }
+
+    createTrajItem(xy_points, z_points);
 }
 
-// 3D ellipse GVF
+// do nothing...
 void GVF_traj_3D_ellipse::genVField() { 
 
+}
+
+/////////////// PRIVATE FUNCTIONS ///////////////
+void GVF_traj_3D_ellipse::set_param(QList<float> param, int8_t _s, QList<float> _phi, float _wb) {
+
+    if (param.size()>6) { // gvf_parametric_3D_ellipse_wp()
+        auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
+        Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
+        ac->getFlightPlan()->getWaypoint((uint8_t)param[6])->getRelative(frame, xy_off.rx(), xy_off.ry());
+
+    } else { // gvf_parametric_3D_ellipse_XYZ()
+        xy_off = QPointF(param[0], param[1]);
+    }
+
+    r = param[2];
+    zl = param[3];
+    zh = param[4];
+    alpha = param[5];
+
+    phi = QVector3D(_phi[0], _phi[1], _phi[2]);
+}
+
+QVector3D GVF_traj_3D_ellipse::traj_point(float t) {
+    QVector3D point;
+
+    point.setX(xy_off.x() + r*cos(t));
+    point.setY(xy_off.y() + r*sin(t));
+    point.setZ(0.5 * (zh + zl + (zl - zh) * sin(alpha - t)));
+    return point;
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.cpp
@@ -1,14 +1,14 @@
 #include "gvf_traj_3D_ellipse.h"
 
-GVF_traj_3D_ellipse::GVF_traj_3D_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings) :
-    GVF_trajectory(id, origin, gvf_settings)
+GVF_traj_3D_ellipse::GVF_traj_3D_ellipse(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, gvf_settings)
 {   
-    set_param(param, _s, phi);
-    update_trajectory();
+    set_param(param, _s, phi, _wb);
+    generate_trajectory();
     
 }
 
-void GVF_traj_3D_ellipse::set_param(QList<float> param, int8_t _s, QList<float> phi) {
+void GVF_traj_3D_ellipse::set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb) {
 
 }
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.cpp
@@ -1,0 +1,25 @@
+#include "gvf_traj_3D_ellipse.h"
+
+GVF_traj_3D_ellipse::GVF_traj_3D_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, origin, gvf_settings)
+{   
+    set_param(param, _s, phi);
+    update_trajectory();
+    
+}
+
+void GVF_traj_3D_ellipse::set_param(QList<float> param, int8_t _s, QList<float> phi) {
+
+}
+
+// 3D ellipse trajectory (parametric representation)
+void GVF_traj_3D_ellipse::genTraj() { 
+    QList<QPointF> points;
+
+    createTrajItem(points);
+}
+
+// 3D ellipse GVF
+void GVF_traj_3D_ellipse::genVField() { 
+
+}

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.h
@@ -7,14 +7,14 @@ class GVF_traj_3D_ellipse : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_3D_ellipse(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings);
+    explicit GVF_traj_3D_ellipse(QString id, QList<float> param, QList<float> _phi, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
-    void set_param(QList<float> param, int8_t _s, QList<float> _phi, float _wb); // GVF PARAMETRIC
+    void set_param(QList<float> param, QList<float> _phi); // GVF PARAMETRIC
     QVector3D traj_point(float t);
 
     float r;
@@ -22,11 +22,7 @@ private:
     float zh;
     float alpha;
 
-    int8_t s;
-
     QVector3D phi;
-
-    float wb;
 };
 
 #endif // GVF_TRAJ_3D_ELLIPSE_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.h
@@ -1,0 +1,29 @@
+#ifndef GVF_TRAJ_3D_ELLIPSE_H
+#define GVF_TRAJ_3D_ELLIPSE_H
+
+#include "gvf_trajectory.h"
+
+class GVF_traj_3D_ellipse : public GVF_trajectory
+{
+    Q_OBJECT
+public:
+    explicit GVF_traj_3D_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings);
+
+protected:
+    virtual void genTraj() override;
+    virtual void genVField() override;
+
+private:
+    void set_param(QList<float> param, int8_t _s, QList<float> phi); // GVF PARAMETRIC
+
+    float r;
+    float zl;
+    float zh;
+    float alpha;
+
+    int8_t s;
+
+    QVector3D phi;
+};
+
+#endif // GVF_TRAJ_3D_ELLIPSE_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.h
@@ -14,7 +14,8 @@ protected:
     virtual void genVField() override;
 
 private:
-    void set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb); // GVF PARAMETRIC
+    void set_param(QList<float> param, int8_t _s, QList<float> _phi, float _wb); // GVF PARAMETRIC
+    QVector3D traj_point(float t);
 
     float r;
     float zl;
@@ -24,6 +25,8 @@ private:
     int8_t s;
 
     QVector3D phi;
+
+    float wb;
 };
 
 #endif // GVF_TRAJ_3D_ELLIPSE_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_ellipse.h
@@ -7,14 +7,14 @@ class GVF_traj_3D_ellipse : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_3D_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings);
+    explicit GVF_traj_3D_ellipse(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
-    void set_param(QList<float> param, int8_t _s, QList<float> phi); // GVF PARAMETRIC
+    void set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb); // GVF PARAMETRIC
 
     float r;
     float zl;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.cpp
@@ -13,8 +13,9 @@ void GVF_traj_3D_lissajous::genTraj() {
     QList<QPointF> xy_points;
     QList<float> z_points;
 
-    float dt = 0.005*2*M_PI;
-    for (float t = 0; t <= 2*M_PI + dt/2; t+=dt) {
+    float max_t = 2*M_PI*2;
+    float dt = 0.001*2*M_PI;
+    for (float t = 0; t <= max_t + dt/2; t+=dt) {
         auto point = traj_point(t);
 
         xy_points.append(QPointF(point.x(),point.y()));

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.cpp
@@ -1,14 +1,14 @@
 #include "gvf_traj_3D_lissajous.h"
 
-GVF_traj_3D_lissajous::GVF_traj_3D_lissajous(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings) :
-    GVF_trajectory(id, origin, gvf_settings)
+GVF_traj_3D_lissajous::GVF_traj_3D_lissajous(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, gvf_settings)
 {   
-    set_param(param, _s, phi);
-    update_trajectory();
+    set_param(param, _s, phi, _wb);
+    generate_trajectory();
     
 }
 
-void GVF_traj_3D_lissajous::set_param(QList<float> param, int8_t _s, QList<float> phi) {
+void GVF_traj_3D_lissajous::set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb) {
 
 }
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.cpp
@@ -1,25 +1,65 @@
 #include "gvf_traj_3D_lissajous.h"
 
-GVF_traj_3D_lissajous::GVF_traj_3D_lissajous(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings) :
+GVF_traj_3D_lissajous::GVF_traj_3D_lissajous(QString id, QList<float> param, QList<float> _phi, QVector<int> *gvf_settings) :
     GVF_trajectory(id, gvf_settings)
 {   
-    set_param(param, _s, phi, _wb);
+    set_param(param, _phi);
     generate_trajectory();
     
 }
 
-void GVF_traj_3D_lissajous::set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb) {
-
-}
-
 // 3D lissajous trajectory (parametric representation)
 void GVF_traj_3D_lissajous::genTraj() { 
-    QList<QPointF> points;
+    QList<QPointF> xy_points;
+    QList<float> z_points;
 
-    createTrajItem(points);
+    float dt = 0.005*2*M_PI;
+    for (float t = 0; t <= 2*M_PI + dt/2; t+=dt) {
+        auto point = traj_point(t);
+
+        xy_points.append(QPointF(point.x(),point.y()));
+        z_points.append(point.z());
+    }
+    
+    createTrajItem(xy_points, z_points);
 }
 
-// 3D lissajous GVF
+// do nothing...
 void GVF_traj_3D_lissajous::genVField() { 
 
+}
+
+/////////////// PRIVATE FUNCTIONS ///////////////
+void GVF_traj_3D_lissajous::set_param(QList<float> param, QList<float> _phi) {
+
+    if (param.size()>14) { // gvf_parametric_3D_lissajous_wp_center
+        auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
+        Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
+        ac->getFlightPlan()->getWaypoint((uint8_t)param[13])->getRelative(frame, xy_off.rx(), xy_off.ry());
+        alt = ac->getFlightPlan()->getWaypoint((uint8_t)param[13])->getAlt();
+
+    } else { // gvf_parametric_3D_lissajous_XYZ
+        xy_off = QPointF(param[0], param[1]);
+        alt = param[2];
+    }
+
+    c = QVector3D(param[3], param[4], param[5]);
+    w = QVector3D(param[6], param[7], param[8]);
+    d = QVector3D(param[9]*M_PI/180, param[10]*M_PI/180, param[11]*M_PI/180);
+
+    alpha = param[12]*M_PI/180;
+
+    phi = QVector3D(_phi[0], _phi[1], _phi[2]); //TODO: Display error in GVF viewer??
+}
+
+QVector3D GVF_traj_3D_lissajous::traj_point(float t) {
+    QVector3D point;
+    
+    float nrx = c.x()*cosf(w.x()*t + d.x());
+    float nry = c.y()*cosf(w.y()*t + d.y());
+
+    point.setX(xy_off.x() + nrx*cosf(alpha) - nry*sinf(alpha));
+    point.setY(xy_off.y() + nrx*sinf(alpha) + nry*cosf(alpha));
+    point.setZ(alt + c.z()*cosf(w.z()*t + d.z()));
+    return point;
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.cpp
@@ -1,0 +1,25 @@
+#include "gvf_traj_3D_lissajous.h"
+
+GVF_traj_3D_lissajous::GVF_traj_3D_lissajous(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, origin, gvf_settings)
+{   
+    set_param(param, _s, phi);
+    update_trajectory();
+    
+}
+
+void GVF_traj_3D_lissajous::set_param(QList<float> param, int8_t _s, QList<float> phi) {
+
+}
+
+// 3D lissajous trajectory (parametric representation)
+void GVF_traj_3D_lissajous::genTraj() { 
+    QList<QPointF> points;
+
+    createTrajItem(points);
+}
+
+// 3D lissajous GVF
+void GVF_traj_3D_lissajous::genVField() { 
+
+}

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.h
@@ -7,26 +7,23 @@ class GVF_traj_3D_lissajous : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_3D_lissajous(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings);
+    explicit GVF_traj_3D_lissajous(QString id, QList<float> param, QList<float> _phi, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
-    void set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb); // GVF PARAMETRIC
+    void set_param(QList<float> param, QList<float> _phi); // GVF PARAMETRIC
+    QVector3D traj_point(float t);
 
-    QVector3D off;
+    double alt;
     QVector3D c;
     QVector3D w;
     QVector3D d;
     float alpha;
 
-    int8_t s;
-
     QVector3D phi;
-
-    float wb;
 };
 
 #endif // GVF_TRAJ_3D_LISSAJOUS_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.h
@@ -7,14 +7,14 @@ class GVF_traj_3D_lissajous : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_3D_lissajous(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings);
+    explicit GVF_traj_3D_lissajous(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
-    void set_param(QList<float> param, int8_t _s, QList<float> phi); // GVF PARAMETRIC
+    void set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb); // GVF PARAMETRIC
 
     QVector3D off;
     QVector3D c;
@@ -25,6 +25,8 @@ private:
     int8_t s;
 
     QVector3D phi;
+
+    float wb;
 };
 
 #endif // GVF_TRAJ_3D_LISSAJOUS_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_3D_lissajous.h
@@ -1,0 +1,30 @@
+#ifndef GVF_TRAJ_3D_LISSAJOUS_H
+#define GVF_TRAJ_3D_LISSAJOUS_H
+
+#include "gvf_trajectory.h"
+
+class GVF_traj_3D_lissajous : public GVF_trajectory
+{
+    Q_OBJECT
+public:
+    explicit GVF_traj_3D_lissajous(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings);
+
+protected:
+    virtual void genTraj() override;
+    virtual void genVField() override;
+
+private:
+    void set_param(QList<float> param, int8_t _s, QList<float> phi); // GVF PARAMETRIC
+
+    QVector3D off;
+    QVector3D c;
+    QVector3D w;
+    QVector3D d;
+    float alpha;
+
+    int8_t s;
+
+    QVector3D phi;
+};
+
+#endif // GVF_TRAJ_3D_LISSAJOUS_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -1,11 +1,12 @@
 #include "gvf_traj_ellipse.h"
 
-GVF_traj_ellipse::GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings) :
+GVF_traj_ellipse::GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
     GVF_trajectory(id, origin, gvf_settings)
 {   
     // INIT
     set_param(param, _s, _ke);
     update_trajectory();
+    
 }
 
 // Get all the necessary parameters to construct the ellipse trajectory
@@ -44,8 +45,10 @@ void GVF_traj_ellipse::genTraj() {
 void GVF_traj_ellipse::genVField() { 
     QList<QPointF> vxy_mesh; 
 
-    float bound_area = 4*a*b; // to scale the arrows
-    xy_mesh = meshGrid(bound_area*4, 24, 24);
+    float bound_area = 8*a*b; // to scale the arrows
+
+    emit DispatcherUi::get()->gvf_defaultFieldSettings(ac_id, round(bound_area), 25, 25);
+    xy_mesh = meshGrid();
 
     foreach (const QPointF &point, xy_mesh) {
         float xel = (point.x() - xy_off.x())*cos(alpha) - (point.y() - xy_off.y())*sin(alpha); 
@@ -67,5 +70,5 @@ void GVF_traj_ellipse::genVField() {
         vxy_mesh.append(QPointF(vx/norm, vy/norm));
     }
 
-    createVFieldItem(xy_mesh, vxy_mesh, bound_area);
+    createVFieldItem(xy_mesh, vxy_mesh);
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -1,7 +1,7 @@
 #include "gvf_traj_ellipse.h"
 
-GVF_traj_ellipse::GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke) :
-    GVF_trajectory(id, origin)
+GVF_traj_ellipse::GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings) :
+    GVF_trajectory(id, origin, gvf_settings)
 {   
     // Get the center of the ellipse 
     if (param.size()>5) { // gvf_ellipse_wp()

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -1,0 +1,6 @@
+#include "gvf_traj_ellipse.h"
+
+GVF_traj_ellipse::GVF_traj_ellipse(QPointF ac_pos, QString ac_id)
+{
+    
+}

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -1,20 +1,35 @@
 #include "gvf_traj_ellipse.h"
 
-GVF_traj_ellipse::GVF_traj_ellipse(uint8_t id, QPointF pos, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke) :
+GVF_traj_ellipse::GVF_traj_ellipse(QString id, QPointF pos, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke) :
     GVF_trajectory(id, pos, origin)
 {   
-    xy_off = QPointF(param[0], param[1]);
+    // Get the center of the ellipse 
+    if (param.size()>5) { // gvf_ellipse_wp()
+        auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(id);
+        Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
+        ac->getFlightPlan()->getWaypoint((uint8_t)param[5])->getRelative(frame, xy_off.rx(), xy_off.ry());
+
+    } else { // gvf_ellipse_XY()
+        xy_off = QPointF(param[0], param[1]);
+    }
+
+    // Get the rest of GVF ellipse trajectory parameters
+    s = _s;
+    ke = _ke;
     a = param[2];
     b = param[3];
     alpha = param[4];
-    s = _s;
-    ke = _ke;
+
+
+    //auto wgs84_xy_off = CoordinatesTransform::get()->relative_utm_to_wgs84(origin, xy_off.x(), xy_off.y());
+    //CoordinatesTransform::get()->wgs84_to_relative_utm(origin, wgs84_xy_off, xy_off.rx(), xy_off.ry());
 
     param_points();
     vector_field();
 }
 
-void GVF_traj_ellipse::param_points() { // Rotated standard ellipse parametric representation
+// Rotated standard ellipse parametric representation
+void GVF_traj_ellipse::param_points() { 
     QList<QPointF> points;
 
     float dt = 0.005*2*M_PI;
@@ -27,11 +42,12 @@ void GVF_traj_ellipse::param_points() { // Rotated standard ellipse parametric r
     createTrajItem(points);
 }
 
-void GVF_traj_ellipse::vector_field() { // Ellipse GVF
+// Ellipse GVF
+void GVF_traj_ellipse::vector_field() { 
     QList<QPointF> vxy_mesh; 
 
-    // TODO: El area y la cantidad de flechas se deben de ajustar al tamaño de la elipse!!
-    xy_mesh = meshGrid(100000, 20, 20);
+    float bound_area = 4*a*b; // to scale the arrows
+    xy_mesh = meshGrid(bound_area*4, 25, 25);
 
     foreach (const QPointF &point, xy_mesh) {
         float xel = (point.x() - xy_off.x())*cos(alpha) - (point.y() - xy_off.y())*sin(alpha); 
@@ -48,11 +64,10 @@ void GVF_traj_ellipse::vector_field() { // Ellipse GVF
         float vx = tx -ke*e*nx;
         float vy = ty -ke*e*ny;
 
-        // TODO: La norma se debe de ajustar al tamaño de la elipse!!
-        float norm = sqrt(pow(vx,2) + pow(vy,2))/12;
+        float norm = sqrt(pow(vx,2) + pow(vy,2));
 
         vxy_mesh.append(QPointF(vx/norm, vy/norm));
     }
 
-    createVFieldItem(xy_mesh, vxy_mesh);
+    createVFieldItem(xy_mesh, vxy_mesh, bound_area);
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -20,14 +20,10 @@ GVF_traj_ellipse::GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float
     b = param[3];
     alpha = param[4];
 
-    //auto wgs84_xy_off = CoordinatesTransform::get()->relative_utm_to_wgs84(origin, xy_off.x(), xy_off.y());
-    //CoordinatesTransform::get()->wgs84_to_relative_utm(origin, wgs84_xy_off, xy_off.rx(), xy_off.ry());
-
     param_points();
     vector_field();
 }
 
-/////////////// PRIVATE FUNCTIONS ///////////////
 // Rotated standard ellipse parametric representation
 void GVF_traj_ellipse::param_points() { 
     QList<QPointF> points;
@@ -61,8 +57,8 @@ void GVF_traj_ellipse::vector_field() {
 
         float e = pow(xel/a,2) + pow(yel/b,2) - 1;
 
-        float vx = tx -ke*e*nx;
-        float vy = ty -ke*e*ny;
+        float vx = tx - ke*e*nx;
+        float vy = ty - ke*e*ny;
 
         float norm = sqrt(pow(vx,2) + pow(vy,2));
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -10,11 +10,29 @@ GVF_traj_ellipse::GVF_traj_ellipse(uint8_t id, QPointF pos, Point2DLatLon origin
     s = _s;
     ke = _ke;
 
-    qDebug() << "a:" << a << " b:" << b << " alpha:" << alpha << " s:" << s << " ke:" << ke;
+    param_points();
+    vector_field();
+}
 
+void GVF_traj_ellipse::param_points() { // Rotated standard ellipse parametric representation
+    QList<QPointF> points;
+
+    float dt = 0.005*2*M_PI;
+    for (int i = 0; i <= 2*M_PI/dt + 1; i++) {
+        float x = xy_off.x() + a*cos(alpha)*cos(dt*i) - b*sin(alpha)*sin(i*dt);
+        float y = xy_off.y() + a*sin(alpha)*cos(dt*i) + b*cos(alpha)*sin(i*dt);
+        points.append(QPointF(x,y));
+    }
+
+    createTrajItem(points);
+}
+
+void GVF_traj_ellipse::vector_field() { // Ellipse GVF
     QList<QPointF> vxy_mesh; 
+
+    // TODO: El area y la cantidad de flechas se deben de ajustar al tamaño de la elipse!!
     xy_mesh = meshGrid(100000, 20, 20);
-    
+
     foreach (const QPointF &point, xy_mesh) {
         float xel = (point.x() - xy_off.x())*cos(alpha) - (point.y() - xy_off.y())*sin(alpha); 
         float yel = (point.x() - xy_off.x())*sin(alpha) + (point.y() - xy_off.y())*cos(alpha); 
@@ -30,10 +48,11 @@ GVF_traj_ellipse::GVF_traj_ellipse(uint8_t id, QPointF pos, Point2DLatLon origin
         float vx = tx -ke*e*nx;
         float vy = ty -ke*e*ny;
 
+        // TODO: La norma se debe de ajustar al tamaño de la elipse!!
         float norm = sqrt(pow(vx,2) + pow(vy,2))/12;
 
         vxy_mesh.append(QPointF(vx/norm, vy/norm));
     }
-    
+
     createVFieldItem(xy_mesh, vxy_mesh);
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -1,7 +1,7 @@
 #include "gvf_traj_ellipse.h"
 
-GVF_traj_ellipse::GVF_traj_ellipse(QString id, QPointF pos, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke) :
-    GVF_trajectory(id, pos, origin)
+GVF_traj_ellipse::GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke) :
+    GVF_trajectory(id, origin)
 {   
     // Get the center of the ellipse 
     if (param.size()>5) { // gvf_ellipse_wp()
@@ -20,7 +20,6 @@ GVF_traj_ellipse::GVF_traj_ellipse(QString id, QPointF pos, Point2DLatLon origin
     b = param[3];
     alpha = param[4];
 
-
     //auto wgs84_xy_off = CoordinatesTransform::get()->relative_utm_to_wgs84(origin, xy_off.x(), xy_off.y());
     //CoordinatesTransform::get()->wgs84_to_relative_utm(origin, wgs84_xy_off, xy_off.rx(), xy_off.ry());
 
@@ -28,6 +27,7 @@ GVF_traj_ellipse::GVF_traj_ellipse(QString id, QPointF pos, Point2DLatLon origin
     vector_field();
 }
 
+/////////////// PRIVATE FUNCTIONS ///////////////
 // Rotated standard ellipse parametric representation
 void GVF_traj_ellipse::param_points() { 
     QList<QPointF> points;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -1,21 +1,20 @@
 #include "gvf_traj_ellipse.h"
 
-GVF_traj_ellipse::GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
-    GVF_trajectory(id, origin, gvf_settings)
+GVF_traj_ellipse::GVF_traj_ellipse(QString id, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, gvf_settings)
 {   
     set_param(param, _s, _ke);
-    update_trajectory();
+    generate_trajectory();
     
 }
 
-// Get all the necessary parameters to construct the ellipse trajectory
 void GVF_traj_ellipse::set_param(QList<float> param, int8_t _s, float _ke) {
     if (param.size()>5) { // gvf_ellipse_wp()
         auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
         Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
         ac->getFlightPlan()->getWaypoint((uint8_t)param[5])->getRelative(frame, xy_off.rx(), xy_off.ry());
 
-    } else { // gvf_ellipse_XY() TODO in firmware
+    } else { // gvf_ellipse_XY()
         xy_off = QPointF(param[0], param[1]);
     }
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -1,6 +1,39 @@
 #include "gvf_traj_ellipse.h"
 
-GVF_traj_ellipse::GVF_traj_ellipse(QPointF ac_pos, QString ac_id)
-{
+GVF_traj_ellipse::GVF_traj_ellipse(uint8_t id, QPointF pos, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke) :
+    GVF_trajectory(id, pos, origin)
+{   
+    xy_off = QPointF(param[0], param[1]);
+    a = param[2];
+    b = param[3];
+    alpha = param[4];
+    s = _s;
+    ke = _ke;
+
+    qDebug() << "a:" << a << " b:" << b << " alpha:" << alpha << " s:" << s << " ke:" << ke;
+
+    QList<QPointF> vxy_mesh; 
+    xy_mesh = meshGrid(100000, 20, 20);
     
+    foreach (const QPointF &point, xy_mesh) {
+        float xel = (point.x() - xy_off.x())*cos(alpha) - (point.y() - xy_off.y())*sin(alpha); 
+        float yel = (point.x() - xy_off.x())*sin(alpha) + (point.y() - xy_off.y())*cos(alpha); 
+
+        float nx =  2*xel*cos(alpha)/pow(a,2) + 2*yel*sin(alpha)/pow(b,2);
+        float ny = -2*xel*sin(alpha)/pow(a,2) + 2*yel*cos(alpha)/pow(b,2);
+
+        float tx =  s*ny;
+        float ty = -s*nx;
+
+        float e = pow(xel/a,2) + pow(yel/b,2) - 1;
+
+        float vx = tx -ke*e*nx;
+        float vy = ty -ke*e*ny;
+
+        float norm = sqrt(pow(vx,2) + pow(vy,2))/12;
+
+        vxy_mesh.append(QPointF(vx/norm, vy/norm));
+    }
+    
+    createVFieldItem(xy_mesh, vxy_mesh);
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.cpp
@@ -27,7 +27,7 @@ void GVF_traj_ellipse::set_param(QList<float> param, int8_t _s, float _ke) {
 }
 
 // Rotated standard ellipse parametric representation
-void GVF_traj_ellipse::param_points() { 
+void GVF_traj_ellipse::genTraj() { 
     QList<QPointF> points;
 
     float dt = 0.005*2*M_PI;
@@ -41,7 +41,7 @@ void GVF_traj_ellipse::param_points() {
 }
 
 // Ellipse GVF
-void GVF_traj_ellipse::vector_field() { 
+void GVF_traj_ellipse::genVField() { 
     QList<QPointF> vxy_mesh; 
 
     float bound_area = 4*a*b; // to scale the arrows

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -7,9 +7,10 @@ class GVF_traj_ellipse : public GVF_trajectory
 {
 
 public:
-    GVF_traj_ellipse(QString id, QPointF pos, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke);
+    GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke);
 
 private:
+    // TODO: Remove private parameters in a next future if I don't use them ...
     float a;
     float b;
     float alpha;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -12,8 +12,8 @@ public:
     virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
 
 protected:
-    virtual void param_points() override;
-    virtual void vector_field() override;
+    virtual void genTraj() override;
+    virtual void genVField() override;
 
 private:
     float a;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -15,6 +15,9 @@ private:
     float alpha;
     int8_t s;
     float ke;
+
+    void param_points();
+    void vector_field();
 };
 
 #endif // GVF_TRAJ_ELLIPSE_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -7,7 +7,7 @@ class GVF_traj_ellipse : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
+    explicit GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
     virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -1,0 +1,16 @@
+#ifndef GVF_TRAJ_ELLIPSE_H
+#define GVF_TRAJ_ELLIPSE_H
+
+#include "gvf_trajectory.h"
+
+class GVF_traj_ellipse : public GVF_trajectory
+{
+
+public:
+    GVF_traj_ellipse(QPointF ac_pos, QString ac_id);
+
+private:
+
+};
+
+#endif // GVF_TRAJ_ELLIPSE_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -7,7 +7,7 @@ class GVF_traj_ellipse : public GVF_trajectory
 {
 
 public:
-    GVF_traj_ellipse(uint8_t id, QPointF pos, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke);
+    GVF_traj_ellipse(QString id, QPointF pos, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke);
 
 private:
     float a;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -7,7 +7,7 @@ class GVF_traj_ellipse : public GVF_trajectory
 {
 
 public:
-    GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke);
+    GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
 
 private:
     // TODO: Remove private parameters in a next future if I don't use them ...

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -7,17 +7,21 @@ class GVF_traj_ellipse : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
+    explicit GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
+
+    virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
+
+protected:
+    virtual void param_points() override;
+    virtual void vector_field() override;
 
 private:
     float a;
     float b;
     float alpha;
+
     int8_t s;
     float ke;
-
-    void param_points();
-    void vector_field();
 };
 
 #endif // GVF_TRAJ_ELLIPSE_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -5,12 +5,11 @@
 
 class GVF_traj_ellipse : public GVF_trajectory
 {
-
+    Q_OBJECT
 public:
     GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
 
 private:
-    // TODO: Remove private parameters in a next future if I don't use them ...
     float a;
     float b;
     float alpha;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -7,10 +7,14 @@ class GVF_traj_ellipse : public GVF_trajectory
 {
 
 public:
-    GVF_traj_ellipse(QPointF ac_pos, QString ac_id);
+    GVF_traj_ellipse(uint8_t id, QPointF pos, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke);
 
 private:
-
+    float a;
+    float b;
+    float alpha;
+    int8_t s;
+    float ke;
 };
 
 #endif // GVF_TRAJ_ELLIPSE_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -9,13 +9,13 @@ class GVF_traj_ellipse : public GVF_trajectory
 public:
     explicit GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
-    virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
-
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
+    void set_param(QList<float> param, int8_t _s, float _ke);
+
     float a;
     float b;
     float alpha;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_ellipse.h
@@ -7,7 +7,7 @@ class GVF_traj_ellipse : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_ellipse(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
+    explicit GVF_traj_ellipse(QString id, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -13,7 +13,8 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
     if(param.size()==6) { // gvf_line_XY1_XY2()
         a = param[0];
         b = param[1];
-
+        qDebug() << "gvf_line_XY1_XY2()";
+        qDebug() << param[0] << param[1] << param[2] << param[3] << param[4];
         float a2 = param[3];
         float b2 = param[4];
 
@@ -25,7 +26,7 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
     } else if (param.size()>3) { // gvf_line_wp1_wp2()
         QPointF xy_wp1;
         QPointF xy_wp2; 
-
+        qDebug() << "gvf_line_wp1_wp2()";
         auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
         Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
         ac->getFlightPlan()->getWaypoint((uint8_t)param[3])->getRelative(frame, xy_wp1.rx(), xy_wp1.ry());
@@ -67,13 +68,15 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
 void GVF_traj_line::genTraj() { 
     QList<QPointF> points;
 
-    float dr = sqrt(pow(dx,2) + pow(dy,2));
+    if (dx + dy != 0) {
+        float dr = sqrt(pow(dx,2) + pow(dy,2));
 
-    float dt = dr/100;
-    for (float t = -d1; t <= dr + d2 + dt/2; t+=dt) {
-        float x = t*sin(course) + a;
-        float y = t*cos(course) + b;
-        points.append(QPointF(x,y));
+        float dt = dr/100;
+        for (float t = -d1; t <= dr + d2 + dt/2; t+=dt) {
+            float x = t*sin(course) + a;
+            float y = t*cos(course) + b;
+            points.append(QPointF(x,y));
+        }
     }
 
     createTrajItem(points);

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -3,12 +3,18 @@
 GVF_traj_line::GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings) :
     GVF_trajectory(id, origin, gvf_settings)
 {   
-    // Get the two points of the line
+    // INIT
+    set_param(param, _s, _ke);
+    update_trajectory();
+}
+
+// Get all the necessary parameters to construct the line trajectory
+void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
     if (param.size()>3) { // gvf_line_wp()
         QPointF xy_wp1;
         QPointF xy_wp2; 
 
-        auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(id);
+        auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
         Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
         ac->getFlightPlan()->getWaypoint((uint8_t)param[3])->getRelative(frame, xy_wp1.rx(), xy_wp1.ry());
         ac->getFlightPlan()->getWaypoint((uint8_t)param[4])->getRelative(frame, xy_wp2.rx(), xy_wp2.ry());
@@ -20,7 +26,7 @@ GVF_traj_line::GVF_traj_line(QString id, Point2DLatLon origin, QList<float> para
         dy = xy_wp2.y() - xy_wp1.y();
 
         course = atan2f(dx, dy);
-        xy_off = QPointF((xy_wp2.x() + xy_wp1.x())/2,(xy_wp2.y() + xy_wp1.y())/2);
+        xy_off = QPointF((xy_wp2.x() + xy_wp1.x())/2,(xy_wp2.y() + xy_wp1.y())/2); //TODO: Vectory field should follow the AC in "non limited" trajectories
 
     } else { // gvf_line_XY()
         a = param[0];
@@ -30,15 +36,11 @@ GVF_traj_line::GVF_traj_line(QString id, Point2DLatLon origin, QList<float> para
         dy = 200;
 
         course = param[2];
-        xy_off = QPointF(a,b);
+        xy_off = QPointF(a,b); //TODO: Vectory field should follow the AC in "non limited" trajectories
     }
 
-    // Get the rest of GVF line trajectory parameters
     s = _s;
     ke = _ke;
-
-    param_points();
-    vector_field();
 }
 
 // Line parametric representation

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -10,7 +10,19 @@ GVF_traj_line::GVF_traj_line(QString id, QList<float> param, int8_t _s, float _k
 // Get all the necessary parameters to construct the line trajectory
 void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
 
-    if (param.size()>3) { // gvf_line_wp1_wp2()
+    if(param.size()==6) { // gvf_line_XY1_XY2()
+        a = param[0];
+        b = param[1];
+
+        float a2 = param[3];
+        float b2 = param[4];
+
+        dx = a2 - a;
+        dy = b2 - b;
+
+        course = param[2];
+        qDebug() << "paso";
+    } else if (param.size()>3) { // gvf_line_wp1_wp2()
         QPointF xy_wp1;
         QPointF xy_wp2; 
 
@@ -35,6 +47,7 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
         dy = 200;
 
         course = param[2];
+        qDebug() << "paso222";
     }
 
     s = _s;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -21,7 +21,7 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
         dy = b2 - b;
 
         course = param[2];
-        qDebug() << "paso";
+
     } else if (param.size()>3) { // gvf_line_wp1_wp2()
         QPointF xy_wp1;
         QPointF xy_wp2; 
@@ -47,7 +47,6 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
         dy = 200;
 
         course = param[2];
-        qDebug() << "paso222";
     }
 
     s = _s;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -51,12 +51,14 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
 
     s = _s;
     ke = _ke;
-    
-    if (param[5]>=0 && param[6]>=0) { // gvf_segment_loop_XY1_XY2
-        d1 = param[5];
-        d2 = param[6];
-        if (abs(course) > M_PI/2) { //TODO: Better fix with course??
-            s *= -1;
+
+    if (param.size() >= 7) { // avoid out of bounds error
+        if (param[5]>=0 && param[6]>=0) { // gvf_segment_loop_XY1_XY2
+            d1 = param[5];
+            d2 = param[6];
+            if (abs(course) > M_PI/2) { //TODO: Better fix with course??
+                s *= -1;
+            }
         }
     }
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -1,10 +1,10 @@
 #include "gvf_traj_line.h"
 
-GVF_traj_line::GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
-    GVF_trajectory(id, origin, gvf_settings)
+GVF_traj_line::GVF_traj_line(QString id, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, gvf_settings)
 {   
     set_param(param, _s, _ke);
-    update_trajectory();
+    generate_trajectory();
 }
 
 // Get all the necessary parameters to construct the line trajectory
@@ -27,7 +27,7 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
 
         course = atan2f(dx, dy);
 
-    } else { // gvf_line_XY() TODO in firmware
+    } else { // gvf_line_XY()
         a = param[0];
         b = param[1];
 
@@ -69,8 +69,8 @@ void GVF_traj_line::genTraj() {
 
 // Line GVF (implicit function)
 void GVF_traj_line::genVField() {
-    QPointF xy_off;
     QList<QPointF> vxy_mesh; 
+    xy_off = getACpos();
     
     float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -48,9 +48,9 @@ void GVF_traj_line::genTraj() {
     QList<QPointF> points;
 
     float dr = sqrt(pow(dx,2) + pow(dy,2));
-    
+
     float dt = dr/100;
-    for (float t = 0; t <=  + dt/2; t+=dt) {
+    for (float t = 0; t <= dr + dt/2; t+=dt) {
         float x = t*sin(course) + a;
         float y = t*cos(course) + b;
         points.append(QPointF(x,y));

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -1,6 +1,6 @@
 #include "gvf_traj_line.h"
 
-GVF_traj_line::GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings) :
+GVF_traj_line::GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
     GVF_trajectory(id, origin, gvf_settings)
 {   
     // INIT
@@ -47,8 +47,10 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
 void GVF_traj_line::genTraj() { 
     QList<QPointF> points;
 
-    int dt = 1;
-    for (float t = 0; t <= sqrt(pow(dx,2) + pow(dy,2)) + dt/2; t+=dt) {
+    float dr = sqrt(pow(dx,2) + pow(dy,2));
+    
+    float dt = dr/100;
+    for (float t = 0; t <=  + dt/2; t+=dt) {
         float x = t*sin(course) + a;
         float y = t*cos(course) + b;
         points.append(QPointF(x,y));
@@ -63,7 +65,9 @@ void GVF_traj_line::genVField() {
     QList<QPointF> vxy_mesh; 
     
     float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows
-    xy_mesh = meshGrid(bound_area*2, 25, 25);
+
+    emit DispatcherUi::get()->gvf_defaultFieldSettings(ac_id, bound_area, 25, 25);
+    xy_mesh = meshGrid(); //4*bound_area TODO: Fix auto scale method
 
     foreach (const QPointF &point, xy_mesh) {
         double nx = -cos(course);
@@ -82,5 +86,5 @@ void GVF_traj_line::genVField() {
         vxy_mesh.append(QPointF(vx/norm, vy/norm));
     }
 
-    createVFieldItem(xy_mesh, vxy_mesh, bound_area, 500);
+    createVFieldItem(xy_mesh, vxy_mesh, 500);
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -1,0 +1,84 @@
+#include "gvf_traj_line.h"
+
+GVF_traj_line::GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings) :
+    GVF_trajectory(id, origin, gvf_settings)
+{   
+    // Get the two points of the line
+    if (param.size()>3) { // gvf_line_wp()
+        QPointF xy_wp1;
+        QPointF xy_wp2; 
+
+        auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(id);
+        Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
+        ac->getFlightPlan()->getWaypoint((uint8_t)param[3])->getRelative(frame, xy_wp1.rx(), xy_wp1.ry());
+        ac->getFlightPlan()->getWaypoint((uint8_t)param[4])->getRelative(frame, xy_wp2.rx(), xy_wp2.ry());
+
+        a = xy_wp1.x();
+        b = xy_wp1.y();
+
+        dx = xy_wp2.x() - xy_wp1.x();
+        dy = xy_wp2.y() - xy_wp1.y();
+
+        course = atan2f(dx, dy);
+        xy_off = QPointF((xy_wp2.x() + xy_wp1.x())/2,(xy_wp2.y() + xy_wp1.y())/2);
+
+    } else { // gvf_line_XY()
+        a = param[0];
+        b = param[1];
+
+        dx = 200;
+        dy = 200;
+
+        course = param[2];
+        xy_off = QPointF(a,b);
+    }
+
+    // Get the rest of GVF line trajectory parameters
+    s = _s;
+    ke = _ke;
+
+    param_points();
+    vector_field();
+}
+
+// Line parametric representation
+void GVF_traj_line::param_points() { 
+    QList<QPointF> points;
+
+    int dt = 1;
+    for (float t = 0; t <= sqrt(pow(dx,2) + pow(dy,2)) + dt/2; t+=dt) {
+        float x = t*sin(course) + a;
+        float y = t*cos(course) + b;
+        points.append(QPointF(x,y));
+    }
+
+    createTrajItem(points);
+}
+
+// Line GVF
+void GVF_traj_line::vector_field() {
+    QPointF xy_off;
+    QList<QPointF> vxy_mesh; 
+    
+    float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows
+    xy_mesh = meshGrid(bound_area*2, 25, 25);
+
+    foreach (const QPointF &point, xy_mesh) {
+        double nx = -cos(course);
+        double ny =  sin(course);
+
+        double tx =  s*ny;
+        double ty = -s*nx;
+
+        double e = (point.x() - a)*nx + (point.y() - b)*ny;
+
+        double vx = tx - (1e-2*ke)*e*nx;
+        double vy = ty - (1e-2*ke)*e*ny;
+
+        double norm = sqrt(pow(vx,2) + pow(vy,2));
+
+        vxy_mesh.append(QPointF(vx/norm, vy/norm));
+    }
+
+    createVFieldItem(xy_mesh, vxy_mesh, bound_area, 500);
+}

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -13,7 +13,7 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
     if(param.size()==6) { // gvf_line_XY1_XY2()
         a = param[0];
         b = param[1];
-        qDebug() << "gvf_line_XY1_XY2()";
+
         qDebug() << param[0] << param[1] << param[2] << param[3] << param[4];
         float a2 = param[3];
         float b2 = param[4];
@@ -26,7 +26,7 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
     } else if (param.size()>3) { // gvf_line_wp1_wp2()
         QPointF xy_wp1;
         QPointF xy_wp2; 
-        qDebug() << "gvf_line_wp1_wp2()";
+
         auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
         Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
         ac->getFlightPlan()->getWaypoint((uint8_t)param[3])->getRelative(frame, xy_wp1.rx(), xy_wp1.ry());
@@ -68,9 +68,10 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
 void GVF_traj_line::genTraj() { 
     QList<QPointF> points;
 
-    if (dx + dy != 0) {
-        float dr = sqrt(pow(dx,2) + pow(dy,2));
+    float dr = sqrt(pow(dx,2) + pow(dy,2));
+    qDebug() << dr;
 
+    if (dr > 0) { 
         float dt = dr/100;
         for (float t = -d1; t <= dr + d2 + dt/2; t+=dt) {
             float x = t*sin(course) + a;
@@ -87,7 +88,7 @@ void GVF_traj_line::genVField() {
     QList<QPointF> vxy_mesh; 
     xy_off = getACpos();
     
-    float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows
+    float bound_area = pow(dx,2) + pow(dy,2) + 1; // to scale the arrows
 
     emit DispatcherUi::get()->gvf_defaultFieldSettings(ac_id, bound_area, 25, 25);
     xy_mesh = meshGrid(); //4*bound_area TODO: Fix auto scale method

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -14,7 +14,6 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
         a = param[0];
         b = param[1];
 
-        qDebug() << param[0] << param[1] << param[2] << param[3] << param[4];
         float a2 = param[3];
         float b2 = param[4];
 
@@ -69,7 +68,6 @@ void GVF_traj_line::genTraj() {
     QList<QPointF> points;
 
     float dr = sqrt(pow(dx,2) + pow(dy,2));
-    qDebug() << dr;
 
     if (dr > 0) { 
         float dt = dr/100;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.cpp
@@ -26,7 +26,6 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
         dy = xy_wp2.y() - xy_wp1.y();
 
         course = atan2f(dx, dy);
-        xy_off = QPointF((xy_wp2.x() + xy_wp1.x())/2,(xy_wp2.y() + xy_wp1.y())/2); //TODO: Vectory field should follow the AC in "non limited" trajectories
 
     } else { // gvf_line_XY()
         a = param[0];
@@ -36,15 +35,16 @@ void GVF_traj_line::set_param(QList<float> param, int8_t _s, float _ke) {
         dy = 200;
 
         course = param[2];
-        xy_off = QPointF(a,b); //TODO: Vectory field should follow the AC in "non limited" trajectories
     }
 
     s = _s;
     ke = _ke;
+    
+    xy_off = getACpos();
 }
 
 // Line parametric representation
-void GVF_traj_line::param_points() { 
+void GVF_traj_line::genTraj() { 
     QList<QPointF> points;
 
     int dt = 1;
@@ -58,7 +58,7 @@ void GVF_traj_line::param_points() {
 }
 
 // Line GVF
-void GVF_traj_line::vector_field() {
+void GVF_traj_line::genVField() {
     QPointF xy_off;
     QList<QPointF> vxy_mesh; 
     

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.h
@@ -12,8 +12,8 @@ public:
     virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
 
 protected:
-    virtual void param_points() override;
-    virtual void vector_field() override;
+    virtual void genTraj() override;
+    virtual void genVField() override;
 
 private:
     float a;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.h
@@ -1,0 +1,26 @@
+#ifndef GVF_TRAJ_LINE_H
+#define GVF_TRAJ_LINE_H
+
+#include "gvf_trajectory.h"
+
+class GVF_traj_line : public GVF_trajectory
+{
+    Q_OBJECT
+public:
+    GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
+
+private:
+    float a;
+    float b;
+    float course;
+    int8_t s;
+    double ke;
+
+    float dx;
+    float dy;
+
+    void param_points();
+    void vector_field();
+};
+
+#endif // GVF_TRAJ_LINE_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.h
@@ -7,7 +7,7 @@ class GVF_traj_line : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
+    explicit GVF_traj_line(QString id, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.h
@@ -7,7 +7,7 @@ class GVF_traj_line : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
+    explicit GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
     virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_line.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_line.h
@@ -9,16 +9,18 @@ class GVF_traj_line : public GVF_trajectory
 public:
     explicit GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
-    virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
-
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
+    void set_param(QList<float> param, int8_t _s, float _ke);
+    
     float a;
     float b;
     float course;
+    float d1 = 0;
+    float d2 = 0;
     
     int8_t s;
     double ke;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
@@ -85,7 +85,7 @@ void GVF_traj_sin::genVField() {
     float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows
 
     emit DispatcherUi::get()->gvf_defaultFieldSettings(ac_id, bound_area, 25, 25);
-    xy_mesh = meshGrid(); //4*bound_area TODO: Fix auto scale method
+    xy_mesh = meshGrid();
 
     foreach (const QPointF &point, xy_mesh) {
         double xs =  (point.x() - a)*sin(course) - (point.y() - b)*cos(course);

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
@@ -1,10 +1,10 @@
 #include "gvf_traj_sin.h"
 
-GVF_traj_sin::GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
-    GVF_trajectory(id, origin, gvf_settings)
+GVF_traj_sin::GVF_traj_sin(QString id, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, gvf_settings)
 {   
     set_param(param, _s, _ke);
-    update_trajectory();
+    generate_trajectory();
 }
 
 // Get all the necessary parameters to construct the sin trajectory
@@ -29,14 +29,14 @@ void GVF_traj_sin::set_param(QList<float> param, int8_t _s, float _ke) {
 
             course = atan2f(dy, dx);
 
-        } else { // gvf_sin_wp_alpha() TODO in firmware
+        } else { // gvf_sin_wp_alpha()
             dx = 200;
             dy = 200;
 
             course = param[2];
         }
 
-    } else {// gvf_sin_XY_alpha() TODO in firmware
+    } else {// gvf_sin_XY_alpha()
         a = param[0];
         b = param[1];
 
@@ -80,6 +80,7 @@ void  GVF_traj_sin::genTraj() {
 // Sin GVF
 void GVF_traj_sin::genVField() {
     QList<QPointF> vxy_mesh; 
+    xy_off = getACpos();
     
     float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
@@ -3,7 +3,6 @@
 GVF_traj_sin::GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
     GVF_trajectory(id, origin, gvf_settings)
 {   
-    // INIT
     set_param(param, _s, _ke);
     update_trajectory();
 }
@@ -30,14 +29,14 @@ void GVF_traj_sin::set_param(QList<float> param, int8_t _s, float _ke) {
 
             course = atan2f(dy, dx);
 
-        } else { // gvf_sin_wp_alpha()
+        } else { // gvf_sin_wp_alpha() TODO in firmware
             dx = 200;
             dy = 200;
 
             course = param[2];
         }
 
-    } else {// gvf_sin_XY_alpha()
+    } else {// gvf_sin_XY_alpha() TODO in firmware
         a = param[0];
         b = param[1];
 
@@ -52,11 +51,15 @@ void GVF_traj_sin::set_param(QList<float> param, int8_t _s, float _ke) {
     A   = param[5];
     s = _s;
     ke = _ke;
-    
+
+    if (abs(course) > M_PI/2) { //TODO: Better fix with course??
+        s *= -1;
+    }
+
     xy_off = getACpos();
 }
 
-// Sin parametric representation
+// Sin trajectory
 void  GVF_traj_sin::genTraj() { 
     QList<QPointF> points;
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
@@ -1,0 +1,109 @@
+#include "gvf_traj_sin.h"
+
+GVF_traj_sin::GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings) :
+    GVF_trajectory(id, origin, gvf_settings)
+{   
+    // INIT
+    set_param(param, _s, _ke);
+    update_trajectory();
+}
+
+// Get all the necessary parameters to construct the sin trajectory
+void GVF_traj_sin::set_param(QList<float> param, int8_t _s, float _ke) {
+    if (param.size()>6) {
+        QPointF xy_wp1;
+        
+        auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
+        Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
+        ac->getFlightPlan()->getWaypoint((uint8_t)param[6])->getRelative(frame, xy_wp1.rx(), xy_wp1.ry());
+
+        a = xy_wp1.x();
+        b = xy_wp1.y();
+
+        if(param.size()>7) { // gvf_sin_wp1_wp2()
+            QPointF xy_wp2;
+            
+            ac->getFlightPlan()->getWaypoint((uint8_t)param[7])->getRelative(frame, xy_wp2.rx(), xy_wp2.ry());
+
+            dx = xy_wp2.x() - xy_wp1.x();
+            dy = xy_wp2.y() - xy_wp1.y();
+
+            course = atan2f(dy, dx);
+
+        } else { // gvf_sin_wp_alpha()
+            dx = 200;
+            dy = 200;
+
+            course = param[2];
+            qDebug() << "gvf_sin_wp_alpha()";
+        }
+
+    } else {// gvf_sin_XY_alpha()
+        a = param[0];
+        b = param[1];
+
+        dx = 200;
+        dy = 200;
+
+        course = param[2];
+        qDebug() << "gvf_sin_XY_alpha()";
+    }
+
+    w   = param[3];
+    off = param[4];
+    A   = param[5];
+    s = _s;
+    ke = _ke;
+    
+    xy_off = QPointF(a,b); //TODO: Vectory field should follow the AC in "non limited" trajectories
+}
+
+// Sin parametric representation
+void  GVF_traj_sin::param_points() { 
+    QList<QPointF> points;
+
+    float dr = sqrt(pow(dx,2) + pow(dy,2));
+
+    int dt = 1;
+    for (float xtr = -2*dr; xtr <= 2*dr + dt/2; xtr+=dt) {
+        float ytr = A*sin(w*xtr + off);
+
+        float x = - xtr*sin(course) + ytr*cos(course) + a;
+        float y =   xtr*cos(course) + ytr*sin(course) + b;
+        points.append(QPointF(x,y));
+    }
+
+    createTrajItem(points);
+}
+
+// Sin GVF
+void GVF_traj_sin::vector_field() {
+    QList<QPointF> vxy_mesh; 
+    
+    float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows
+    xy_mesh = meshGrid(bound_area*2, 25, 25);
+
+    foreach (const QPointF &point, xy_mesh) {
+        double xs =  (point.x() - a)*sin(course) - (point.y() - b)*cos(course);
+        double ys = -(point.x() - a)*cos(course) - (point.y() - b)*sin(course);
+
+        double ang = w*xs + off;
+
+        double nx = -cos(course) - A*w*cos(ang)*sin(course);
+        double ny = -sin(course) + A*w*cos(ang)*cos(course);
+
+        double tx =  s*ny;
+        double ty = -s*nx;
+
+        double e = ys - A*sin(ang);
+
+        double vx = tx - (1e-2*ke)*e*nx;
+        double vy = ty - (1e-2*ke)*e*ny;
+
+        double norm = sqrt(pow(vx,2) + pow(vy,2));
+
+        vxy_mesh.append(QPointF(vx/norm, vy/norm));
+    }
+
+    createVFieldItem(xy_mesh, vxy_mesh, bound_area, 500);
+}

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
@@ -35,7 +35,6 @@ void GVF_traj_sin::set_param(QList<float> param, int8_t _s, float _ke) {
             dy = 200;
 
             course = param[2];
-            qDebug() << "gvf_sin_wp_alpha()";
         }
 
     } else {// gvf_sin_XY_alpha()
@@ -46,7 +45,6 @@ void GVF_traj_sin::set_param(QList<float> param, int8_t _s, float _ke) {
         dy = 200;
 
         course = param[2];
-        qDebug() << "gvf_sin_XY_alpha()";
     }
 
     w   = param[3];
@@ -55,11 +53,11 @@ void GVF_traj_sin::set_param(QList<float> param, int8_t _s, float _ke) {
     s = _s;
     ke = _ke;
     
-    xy_off = QPointF(a,b); //TODO: Vectory field should follow the AC in "non limited" trajectories
+    xy_off = getACpos();
 }
 
 // Sin parametric representation
-void  GVF_traj_sin::param_points() { 
+void  GVF_traj_sin::genTraj() { 
     QList<QPointF> points;
 
     float dr = sqrt(pow(dx,2) + pow(dy,2));
@@ -77,7 +75,7 @@ void  GVF_traj_sin::param_points() {
 }
 
 // Sin GVF
-void GVF_traj_sin::vector_field() {
+void GVF_traj_sin::genVField() {
     QList<QPointF> vxy_mesh; 
     
     float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.cpp
@@ -1,6 +1,6 @@
 #include "gvf_traj_sin.h"
 
-GVF_traj_sin::GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings) :
+GVF_traj_sin::GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings) :
     GVF_trajectory(id, origin, gvf_settings)
 {   
     // INIT
@@ -62,9 +62,9 @@ void  GVF_traj_sin::genTraj() {
 
     float dr = sqrt(pow(dx,2) + pow(dy,2));
 
-    int dt = 1;
+    float dt = dr/100;
     for (float xtr = -2*dr; xtr <= 2*dr + dt/2; xtr+=dt) {
-        float ytr = A*sin(w*xtr + off);
+        float ytr = A*sin(w*xtr - off);
 
         float x = - xtr*sin(course) + ytr*cos(course) + a;
         float y =   xtr*cos(course) + ytr*sin(course) + b;
@@ -79,7 +79,9 @@ void GVF_traj_sin::genVField() {
     QList<QPointF> vxy_mesh; 
     
     float bound_area = pow(dx,2) + pow(dy,2); // to scale the arrows
-    xy_mesh = meshGrid(bound_area*2, 25, 25);
+
+    emit DispatcherUi::get()->gvf_defaultFieldSettings(ac_id, bound_area, 25, 25);
+    xy_mesh = meshGrid(); //4*bound_area TODO: Fix auto scale method
 
     foreach (const QPointF &point, xy_mesh) {
         double xs =  (point.x() - a)*sin(course) - (point.y() - b)*cos(course);
@@ -103,5 +105,5 @@ void GVF_traj_sin::genVField() {
         vxy_mesh.append(QPointF(vx/norm, vy/norm));
     }
 
-    createVFieldItem(xy_mesh, vxy_mesh, bound_area, 500);
+    createVFieldItem(xy_mesh, vxy_mesh, 500);
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
@@ -12,8 +12,8 @@ public:
     virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
 
 protected:
-    virtual void param_points() override;
-    virtual void vector_field() override;
+    virtual void genTraj() override;
+    virtual void genVField() override;
 
 private:
     float a;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
@@ -1,13 +1,13 @@
-#ifndef GVF_TRAJ_LINE_H
-#define GVF_TRAJ_LINE_H
+#ifndef GVF_TRAJ_SIN_H
+#define GVF_TRAJ_SIN_H
 
 #include "gvf_trajectory.h"
 
-class GVF_traj_line : public GVF_trajectory
+class GVF_traj_sin : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_line(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
+    explicit GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
 
     virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
 
@@ -19,7 +19,10 @@ private:
     float a;
     float b;
     float course;
-    
+    float w;
+    float off;
+    float A;
+
     int8_t s;
     double ke;
 
@@ -27,4 +30,4 @@ private:
     float dy;
 };
 
-#endif // GVF_TRAJ_LINE_H
+#endif // GVF_TRAJ_SIN_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
@@ -9,13 +9,13 @@ class GVF_traj_sin : public GVF_trajectory
 public:
     explicit GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
-    virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
-
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
+    void set_param(QList<float> param, int8_t _s, float _ke);
+    
     float a;
     float b;
     float course;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
@@ -7,7 +7,7 @@ class GVF_traj_sin : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
+    explicit GVF_traj_sin(QString id, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_sin.h
@@ -7,7 +7,7 @@ class GVF_traj_sin : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QList<float> gvf_settings);
+    explicit GVF_traj_sin(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, float _ke, QVector<int> *gvf_settings);
 
     virtual void set_param(QList<float> param, int8_t _s, float _ke) override;
 

--- a/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.cpp
@@ -38,7 +38,7 @@ void GVF_traj_trefoil::genVField() {
 }
 
 /////////////// PRIVATE FUNCTIONS ///////////////
-void GVF_traj_trefoil::set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb) {
+void GVF_traj_trefoil::set_param(QList<float> param, int8_t _s, QList<float> _phi, float _wb) {
     if (param.size()>7) { // gvf_parametric_2D_trefoil_wp()
         auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
         Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();

--- a/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.cpp
@@ -1,9 +1,9 @@
 #include "gvf_traj_trefoil.h"
 
-GVF_traj_trefoil::GVF_traj_trefoil(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings) :
+GVF_traj_trefoil::GVF_traj_trefoil(QString id, QList<float> param, QList<float> _phi, QVector<int> *gvf_settings) :
     GVF_trajectory(id, gvf_settings)
 {   
-    set_param(param, _s, phi, _wb);
+    set_param(param, _phi);
     generate_trajectory();
 }
 
@@ -38,7 +38,7 @@ void GVF_traj_trefoil::genVField() {
 }
 
 /////////////// PRIVATE FUNCTIONS ///////////////
-void GVF_traj_trefoil::set_param(QList<float> param, int8_t _s, QList<float> _phi, float _wb) {
+void GVF_traj_trefoil::set_param(QList<float> param, QList<float> _phi) {
     if (param.size()>7) { // gvf_parametric_2D_trefoil_wp()
         auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
         Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
@@ -54,8 +54,7 @@ void GVF_traj_trefoil::set_param(QList<float> param, int8_t _s, QList<float> _ph
     r = param[5];
     alpha = param[6]*M_PI/180;
 
-    s = _s;
-    wb = _wb;
+    phi = QPointF(_phi[0], _phi[1]); //TODO: Display error in GVF viewer??
 }
 
 QPointF GVF_traj_trefoil::traj_point(float t) {

--- a/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.cpp
@@ -1,0 +1,25 @@
+#include "gvf_traj_trefoil.h"
+
+GVF_traj_trefoil::GVF_traj_trefoil(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, origin, gvf_settings)
+{   
+    set_param(param, _s, phi);
+    update_trajectory();
+}
+
+// Get all the necessary parameters to construct the ellipse trajectory
+void GVF_traj_trefoil::set_param(QList<float> param, int8_t _s, QList<float> phi) {
+
+}
+
+// 2D trefoil trajectory (parametric representation)
+void GVF_traj_trefoil::genTraj() { 
+    QList<QPointF> points;
+
+    createTrajItem(points);
+}
+
+// 2D trefoil GVF 
+void GVF_traj_trefoil::genVField() { 
+
+}

--- a/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.cpp
@@ -1,25 +1,75 @@
 #include "gvf_traj_trefoil.h"
 
-GVF_traj_trefoil::GVF_traj_trefoil(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings) :
-    GVF_trajectory(id, origin, gvf_settings)
+GVF_traj_trefoil::GVF_traj_trefoil(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings) :
+    GVF_trajectory(id, gvf_settings)
 {   
-    set_param(param, _s, phi);
-    update_trajectory();
+    set_param(param, _s, phi, _wb);
+    generate_trajectory();
 }
 
-// Get all the necessary parameters to construct the ellipse trajectory
-void GVF_traj_trefoil::set_param(QList<float> param, int8_t _s, QList<float> phi) {
-
-}
-
-// 2D trefoil trajectory (parametric representation)
+// 2D trefoil knot trajectory (parametric representation)
 void GVF_traj_trefoil::genTraj() { 
     QList<QPointF> points;
+    
+    float res = 1e7;
+    float N;
+
+    if (w1>w2) {
+        N = 1/gcd(res*w1,res*w2)*res;
+    } else {
+        N = 1/gcd(res*w2,res*w1)*res;
+    }
+
+    float max_t = 2*M_PI*N;
+    float num_pts = N*10;
+
+    float dt = max_t /num_pts;
+    for (float t = 0; t <= max_t + dt/2; t+=dt) {
+        points.append(traj_point(t));
+    }
 
     createTrajItem(points);
 }
 
-// 2D trefoil GVF 
+
+// 2D trefoil knot GVF 
 void GVF_traj_trefoil::genVField() { 
 
+}
+
+/////////////// PRIVATE FUNCTIONS ///////////////
+void GVF_traj_trefoil::set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb) {
+    if (param.size()>7) { // gvf_parametric_2D_trefoil_wp()
+        auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
+        Waypoint::WpFrame frame = ac->getFlightPlan()->getFrame();
+        ac->getFlightPlan()->getWaypoint((uint8_t)param[7])->getRelative(frame, xy_off.rx(), xy_off.ry());
+
+    } else { // gvf_parametric_2D_trefoil_XY()
+        xy_off = QPointF(param[0], param[1]);
+    }
+
+    w1 = param[2];
+    w2 = param[3];
+    ratio = param[4];
+    r = param[5];
+    alpha = param[6]*M_PI/180;
+
+    s = _s;
+    wb = _wb;
+}
+
+QPointF GVF_traj_trefoil::traj_point(float t) {
+    float xnr = cos(w1*t) * (r*cos(w2*t) + ratio);
+    float ynr = sin(w1*t) * (r*cos(w2*t) + ratio);
+
+    float x =  xy_off.x() + cos(alpha)*xnr - sin(alpha)*ynr;
+    float y =  xy_off.y() + sin(alpha)*xnr + cos(alpha)*ynr;
+
+    return QPointF(x,y);
+}
+
+float GVF_traj_trefoil::gcd(int a, int b){
+    if(b == 0)
+        return a;
+    return gcd(b, a % b);
 }

--- a/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.h
@@ -1,0 +1,31 @@
+#ifndef GVF_TRAJ_TREFOIL_H
+#define GVF_TRAJ_TREFOIL_H
+
+#include "gvf_trajectory.h"
+
+class GVF_traj_trefoil : public GVF_trajectory
+{
+    Q_OBJECT
+public:
+    explicit GVF_traj_trefoil(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings);
+
+protected:
+    virtual void genTraj() override;
+    virtual void genVField() override;
+
+private:
+    void set_param(QList<float> param, int8_t _s, QList<float> phi); // GVF PARAMETRIC
+
+    float w1;
+    float w2;
+    float ratio;
+    float r;
+    float alpha;
+
+    int8_t s;
+
+    float phi_x;
+    float phi_y;
+};
+
+#endif // GVF_TRAJ_TREFOIL_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.h
@@ -14,7 +14,7 @@ protected:
     virtual void genVField() override;
 
 private:
-    void set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb); // GVF PARAMETRIC
+    void set_param(QList<float> param, int8_t _s, QList<float> _phi, float _wb); // GVF PARAMETRIC
     QPointF traj_point(float t);
 
     float w1;

--- a/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.h
@@ -7,14 +7,15 @@ class GVF_traj_trefoil : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_trefoil(QString id, Point2DLatLon origin, QList<float> param, int8_t _s, QList<float> phi, QVector<int> *gvf_settings);
+    explicit GVF_traj_trefoil(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
-    void set_param(QList<float> param, int8_t _s, QList<float> phi); // GVF PARAMETRIC
+    void set_param(QList<float> param, int8_t _s, QList<float> phi, float _wb); // GVF PARAMETRIC
+    QPointF traj_point(float t);
 
     float w1;
     float w2;
@@ -26,6 +27,10 @@ private:
 
     float phi_x;
     float phi_y;
+
+    float wb;
+
+    float gcd(int a, int b);
 };
 
 #endif // GVF_TRAJ_TREFOIL_H

--- a/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.h
+++ b/src/widgets/map/gvf_trajectories/gvf_traj_trefoil.h
@@ -7,14 +7,14 @@ class GVF_traj_trefoil : public GVF_trajectory
 {
     Q_OBJECT
 public:
-    explicit GVF_traj_trefoil(QString id, QList<float> param, int8_t _s, QList<float> phi, float _wb, QVector<int> *gvf_settings);
+    explicit GVF_traj_trefoil(QString id, QList<float> param, QList<float> _phi, QVector<int> *gvf_settings);
 
 protected:
     virtual void genTraj() override;
     virtual void genVField() override;
 
 private:
-    void set_param(QList<float> param, int8_t _s, QList<float> _phi, float _wb); // GVF PARAMETRIC
+    void set_param(QList<float> param, QList<float> _phi); // GVF PARAMETRIC
     QPointF traj_point(float t);
 
     float w1;
@@ -23,12 +23,7 @@ private:
     float r;
     float alpha;
 
-    int8_t s;
-
-    float phi_x;
-    float phi_y;
-
-    float wb;
+    QPointF phi;
 
     float gcd(int a, int b);
 };

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -85,12 +85,33 @@ void GVF_trajectory::update_origin() {
 
 /////////////// PRIVATE FUNCTIONS ///////////////
 // Create graphics object 
-void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
+void GVF_trajectory::createTrajItem(QList<QPointF> points)
 {
     for(auto point: points) {
         auto pos = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, point.x(), point.y());
         auto wp =  new WaypointItem(pos, ac_id, Qt::green); 
         traj_item->addPoint(wp);
+        traj_waypoints.append(wp);
+    }
+
+    traj_item->setText("AC " + ac_id + " GVF");
+    //traj_item->setVisible(traj_item_vis); //(TODO)
+}
+
+void GVF_trajectory::createTrajItem(QList<QPointF> xy_points, QList<float> z_points)
+{
+    auto mm = minmax_element(z_points.begin(), z_points.end());
+    float zmin = *mm.first;
+    float zmax = *mm.second;
+    
+    for(int i = 0; i < xy_points.size(); i++) {
+        int g = round((z_points[i] - zmin)/(zmax - zmin) * 255);
+        int r = 255 - g;
+        auto traj_color = QColor(r,g,0);
+
+        auto pos = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, xy_points[i].x(), xy_points[i].y());
+        auto wp =  new WaypointItem(pos, ac_id, traj_color); 
+        traj_item->addPoint(wp, traj_color);
         traj_waypoints.append(wp);
     }
 

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -22,13 +22,13 @@ GVF_trajectory::GVF_trajectory(QString id, QVector<int> *gvf_settings)
             if(sender == ac_id) {
                 auto gvfV_settings = *gvf_settings;
 
-                traj_item_vis  = gvfV_settings[0];
-                field_item_vis = gvfV_settings[1];
+                setTrajVis(gvfV_settings[0]);
+                setVFiledVis(gvfV_settings[1]);
                 field_area = gvfV_settings[2];
                 field_xpts = gvfV_settings[3];
                 field_ypts = gvfV_settings[4];  
 
-                setVFiledVis(field_item_vis);
+
             }
         });
 }
@@ -41,10 +41,20 @@ QuiverItem* GVF_trajectory::getVField() {
     return field_item;
 }
 
+void GVF_trajectory::setTrajVis(bool vis) {
+    traj_item_vis = vis;
+    traj_item->setVisible(traj_item_vis);
+    
+    if(vis) {
+        traj_item->setText("AC " + ac_id + " GVF");
+    } else {
+        traj_item->setText("");
+    }
+}
+
 void GVF_trajectory::setVFiledVis(bool vis) {
     field_item_vis = vis;
     field_item->setVisible(field_item_vis);
-
 }
 
 // We have to disconnect from dispatcher and delete previous waypoints 
@@ -84,7 +94,8 @@ void GVF_trajectory::update_origin() {
 }
 
 /////////////// PRIVATE FUNCTIONS ///////////////
-// Create graphics object 
+// - Create graphics object -
+// GVF classic trajectory
 void GVF_trajectory::createTrajItem(QList<QPointF> points)
 {   
     emit DispatcherUi::get()->gvf_zlimits(ac_id, 0, 0);
@@ -96,10 +107,10 @@ void GVF_trajectory::createTrajItem(QList<QPointF> points)
         traj_waypoints.append(wp);
     }
 
-    traj_item->setText("AC " + ac_id + " GVF");
-    //traj_item->setVisible(traj_item_vis); //(TODO)
+    setTrajVis(traj_item_vis);
 }
 
+// GVF parametric trajectory
 void GVF_trajectory::createTrajItem(QList<QPointF> xy_points, QList<float> z_points)
 {
     auto mm = minmax_element(z_points.begin(), z_points.end());
@@ -122,10 +133,10 @@ void GVF_trajectory::createTrajItem(QList<QPointF> xy_points, QList<float> z_poi
         traj_waypoints.append(wp);
     }
 
-    traj_item->setText("AC " + ac_id + " GVF");
-    //traj_item->setVisible(traj_item_vis); //(TODO)
+    setTrajVis(traj_item_vis);
 }
 
+// GVF vector field
 void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float ref_field_area) 
 {  
     // Arrows scaling based on the trajectory bounding field area, xpts and ypts
@@ -146,10 +157,10 @@ void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoi
         field_item->addQuiver(pos_latlon, vpos_latlon);  
     }
 
-    field_item->setVisible(field_item_vis);
+    setVFiledVis(field_item_vis);
 }
 
-// Create the XY mesh to draw the vector field
+// - Create the XY mesh to draw the vector field -
 QList<QPointF> GVF_trajectory::meshGrid() 
 {
     QList<QPointF> grid;
@@ -165,7 +176,7 @@ QList<QPointF> GVF_trajectory::meshGrid()
     return grid;
 }
 
-// Get AC position into the LTP
+// - Get AC position into the LTP -
 QPointF GVF_trajectory::getACpos() {
     auto latlon = Point2DLatLon(0,0);
 

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -105,13 +105,17 @@ void GVF_trajectory::createTrajItem(QList<QPointF> xy_points, QList<float> z_poi
     auto mm = minmax_element(z_points.begin(), z_points.end());
     float zmin = *mm.first;
     float zmax = *mm.second;
-
+    qDebug() << "zmin" << zmin << " zmax" << zmax;
     emit DispatcherUi::get()->gvf_zlimits(ac_id, zmin, zmax);
 
     for(int i = 0; i < xy_points.size(); i++) {
-        int g = round((z_points[i] - zmin)/(zmax - zmin) * 255);
-        int r = 255 - g;
-        auto traj_color = QColor(r,g,0);
+        auto traj_color = QColor(Qt::green);
+
+        if (!(zmax == zmin)) {
+            int g = round((z_points[i] - zmin)/(zmax - zmin) * 255);
+            int r = 255 - g;
+            traj_color.setRgb(r,g,0);
+        }
         
         auto pos = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, xy_points[i].x(), xy_points[i].y());
         auto wp =  new WaypointItem(pos, ac_id, traj_color); 

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -105,7 +105,6 @@ void GVF_trajectory::createTrajItem(QList<QPointF> xy_points, QList<float> z_poi
     auto mm = minmax_element(z_points.begin(), z_points.end());
     float zmin = *mm.first;
     float zmax = *mm.second;
-    qDebug() << "zmin" << zmin << " zmax" << zmax;
     emit DispatcherUi::get()->gvf_zlimits(ac_id, zmin, zmax);
 
     for(int i = 0; i < xy_points.size(); i++) {

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -1,10 +1,8 @@
 #include "gvf_trajectory.h"
-#include "mapwidget.h"
 
-GVF_trajectory::GVF_trajectory(QString id, QPointF pos, Point2DLatLon origin)
+GVF_trajectory::GVF_trajectory(QString id, Point2DLatLon origin)
 {
     ac_id = id;
-    ac_pos = pos;
     ltp_origin = origin;
 }
 
@@ -51,7 +49,6 @@ void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
     for(auto point: points) {
         auto pos = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, point.x(), point.y());
         auto wp =  new WaypointItem(pos, ac_id, color); 
-        wp->setStyle(GraphicsObject::Style::CURRENT_NAV);
         traj_item->addPoint(wp);
         traj_waypoints.append(wp);
     }

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -86,7 +86,9 @@ void GVF_trajectory::update_origin() {
 /////////////// PRIVATE FUNCTIONS ///////////////
 // Create graphics object 
 void GVF_trajectory::createTrajItem(QList<QPointF> points)
-{
+{   
+    emit DispatcherUi::get()->gvf_zlimits(ac_id, 0, 0);
+
     for(auto point: points) {
         auto pos = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, point.x(), point.y());
         auto wp =  new WaypointItem(pos, ac_id, Qt::green); 
@@ -103,12 +105,14 @@ void GVF_trajectory::createTrajItem(QList<QPointF> xy_points, QList<float> z_poi
     auto mm = minmax_element(z_points.begin(), z_points.end());
     float zmin = *mm.first;
     float zmax = *mm.second;
-    
+
+    emit DispatcherUi::get()->gvf_zlimits(ac_id, zmin, zmax);
+
     for(int i = 0; i < xy_points.size(); i++) {
         int g = round((z_points[i] - zmin)/(zmax - zmin) * 255);
         int r = 255 - g;
         auto traj_color = QColor(r,g,0);
-
+        
         auto pos = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, xy_points[i].x(), xy_points[i].y());
         auto wp =  new WaypointItem(pos, ac_id, traj_color); 
         traj_item->addPoint(wp, traj_color);

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -1,6 +1,70 @@
 #include "gvf_trajectory.h"
+#include "mapwidget.h"
+#include "gcs_utils.h"
 
-GVF_trajectory::GVF_trajectory()
+GVF_trajectory::GVF_trajectory(uint8_t id, QPointF pos, Point2DLatLon origin)
 {
-    
+    ac_id = id;
+    ac_pos = pos;
+    ltp_origin = origin;
+}
+
+QList<QPointF> GVF_trajectory::meshGrid(float area, int xpoints_num, int ypoints_num)
+{
+    QList<QPointF> grid;
+
+    float dx = sqrt(area)/(xpoints_num - 1);
+    float dy = sqrt(area)/(ypoints_num - 1);
+    for(float x=xy_off.x() - 0.5*sqrt(area); x<=xy_off.x() + 0.5*sqrt(area) + dx/2; x+=dx) {
+        for(float y=xy_off.y() - 0.5*sqrt(area); y<=xy_off.y() + 0.5*sqrt(area) + dy/2; y+=dy) {
+            grid.append(QPointF(x,y));
+        }
+    }
+
+    return grid;
+}
+
+QuiverItem* GVF_trajectory::getVField() {
+    return vector_field;
+}
+
+void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
+{
+    (void)points;
+    //     auto pi = new PathItem("__NO_AC__", palette);
+    //     if(shape == 1) {    // Polygon
+    //         pi->setFilled(true);
+    //         pi->setClosedPath(true);
+    //     }
+    //     pi->setZValues(z, z);
+    //     for(auto pos: points) {
+    //         auto wi = new WaypointItem(pos, "__NO_AC__", palette);
+    //         //wcenter->setEditable(false);
+    //         //wcenter->setZValues(z, z);
+    //         addItem(wi);
+    //         wi->setStyle(GraphicsObject::Style::CURRENT_NAV);
+    //         pi->addPoint(wi);
+    //     }
+    //     pi->setText(text);
+    //     addItem(pi);
+    //     item = pi;
+
+    // }
+
+    // if(item != nullptr && !shape_id.isNull()) {
+    //     shapes[shape_id] = item;
+    // }
+}
+
+void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints) 
+{
+    QList<Point2DLatLon> pos;
+    QList<Point2DLatLon> vpos;
+
+    for (int i=0; i<points.size(); i++) {
+        pos.append(CoordinatesTransform::get()->ltp_to_wgs84(ltp_origin, points[i].x(), points[i].y()));
+        vpos.append(CoordinatesTransform::get()->ltp_to_wgs84(pos[i], vpoints[i].x(), vpoints[i].y()));
+    }
+
+    vector_field = new QuiverItem(pos, vpos,  QString::number(ac_id));
 }

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -6,15 +6,15 @@ GVF_trajectory::GVF_trajectory(QString id, Point2DLatLon origin, QList<float> gv
     ac_id = id;
     ltp_origin = origin;
     traj_item_vis = (int)gvf_settings[0];
-    vector_field_vis = (int)gvf_settings[1];
+    field_item_vis = (int)gvf_settings[1];
 
     // If you're alive, please update your visibility when gvf_viewer request it 
     connect(DispatcherUi::get(), &DispatcherUi::gvf_settingUpdated, this,
         [=](QString sender, bool traj_vis, bool field_vis) {
             if(sender == ac_id) {
                 traj_item_vis = traj_vis;
-                vector_field_vis = field_vis;
-                setVFiledVis(vector_field_vis);
+                field_item_vis = field_vis;
+                setVFiledVis(field_item_vis);
             }
         });  
 }
@@ -24,12 +24,12 @@ PathItem* GVF_trajectory::getTraj() {
 }
 
 QuiverItem* GVF_trajectory::getVField() {
-    return vector_field;
+    return field_item;
 }
 
 void GVF_trajectory::setVFiledVis(bool vis) {
-    vector_field_vis = vis;
-    vector_field->setVisible(vector_field_vis);
+    field_item_vis = vis;
+    field_item->setVisible(field_item_vis);
 
 }
 
@@ -44,6 +44,13 @@ void GVF_trajectory::purge_trajectory() {
     }
 }
 
+// Regenerate the trajectory points and the vectory field
+void GVF_trajectory::update_trajectory() {
+    param_points();
+    vector_field();
+}
+
+/////////////// PRIVATE FUNCTIONS ///////////////
 // Create graphics object 
 void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
 {
@@ -84,13 +91,11 @@ void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoi
     }
     
     auto color = Qt::red;
-    vector_field = new QuiverItem(pos, vpos, ac_id, color, 0.5);
-    vector_field->setVisible(vector_field_vis);
+    field_item = new QuiverItem(pos, vpos, ac_id, color, 0.5);
+    field_item->setVisible(field_item_vis);
 }
 
-
-
-/////////////// UTILITY FUNCTIONS ///////////////
+// Create the XY mesh to draw the vectory field
 QList<QPointF> GVF_trajectory::meshGrid(float area, int xpoints_num, int ypoints_num)
 {
     QList<QPointF> grid;

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -26,9 +26,7 @@ GVF_trajectory::GVF_trajectory(QString id, QVector<int> *gvf_settings)
                 setVFiledVis(gvfV_settings[1]);
                 field_area = gvfV_settings[2];
                 field_xpts = gvfV_settings[3];
-                field_ypts = gvfV_settings[4];  
-
-
+                field_ypts = gvfV_settings[4];
             }
         });
 }

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -33,7 +33,8 @@ void GVF_trajectory::setVFiledVis(bool vis) {
 
 }
 
-// We have to disconnect from dispatcher and delete previous waypoints if we don't want to cause memory overflow!!
+// We have to disconnect from dispatcher and delete previous waypoints 
+// if we don't want to cause memory dump or memory overflow!!
 void GVF_trajectory::purge_trajectory() {
     disconnect(DispatcherUi::get(), &DispatcherUi::gvf_settingUpdated, this, 0); 
 
@@ -46,7 +47,6 @@ void GVF_trajectory::purge_trajectory() {
 // Create graphics object 
 void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
 {
-    //auto color = AircraftManager::get()->getAircraft(ac_id)->getColor();
     auto color = Qt::green;
 
     traj_item = new PathItem(ac_id, color);
@@ -63,12 +63,14 @@ void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
     //traj_item->setVisible(traj_item_vis); (TODO)
 }
 
-void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area) 
+void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area, float ref_area) 
 {   
     QList<Point2DLatLon> pos;
     QList<Point2DLatLon> vpos;
 
-    float scale = sqrt(150/bound_area); // arrows scaling based on the trajectory bounding area
+    // Arrows scaling based on the trajectory bounding area
+    float scale = sqrt(ref_area/bound_area); 
+
     for (int i=0; i<points.size(); i++) {
         float vx = vpoints[i].x();
         float vy = vpoints[i].y();
@@ -81,7 +83,6 @@ void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoi
         vpos.append(CoordinatesTransform::get()->ltp_to_wgs84(pos[i], vx, vy));
     }
     
-    //auto color = AircraftManager::get()->getAircraft(ac_id)->getColor();
     auto color = Qt::red;
     vector_field = new QuiverItem(pos, vpos, ac_id, color, 0.5);
     vector_field->setVisible(vector_field_vis);

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -1,24 +1,22 @@
 #include "gvf_trajectory.h"
+#include "dispatcher_ui.h"
 
-GVF_trajectory::GVF_trajectory(QString id, Point2DLatLon origin)
+GVF_trajectory::GVF_trajectory(QString id, Point2DLatLon origin, QList<float> gvf_settings)
 {
     ac_id = id;
     ltp_origin = origin;
-}
+    traj_item_vis = (int)gvf_settings[0];
+    vector_field_vis = (int)gvf_settings[1];
 
-QList<QPointF> GVF_trajectory::meshGrid(float area, int xpoints_num, int ypoints_num)
-{
-    QList<QPointF> grid;
-
-    float dx = sqrt(area)/(xpoints_num - 1);
-    float dy = sqrt(area)/(ypoints_num - 1);
-    for(float x=xy_off.x() - 0.5*sqrt(area); x<=xy_off.x() + 0.5*sqrt(area) + dx/2; x+=dx) {
-        for(float y=xy_off.y() - 0.5*sqrt(area); y<=xy_off.y() + 0.5*sqrt(area) + dy/2; y+=dy) {
-            grid.append(QPointF(x,y));
-        }
-    }
-
-    return grid;
+    // If you're alive, please update your visibility when gvf_viewer request it 
+    connect(DispatcherUi::get(), &DispatcherUi::gvf_settingUpdated, this,
+        [=](QString sender, bool traj_vis, bool field_vis) {
+            if(sender == ac_id) {
+                traj_item_vis = traj_vis;
+                vector_field_vis = field_vis;
+                setVFiledVis(vector_field_vis);
+            }
+        });  
 }
 
 PathItem* GVF_trajectory::getTraj() {
@@ -29,21 +27,29 @@ QuiverItem* GVF_trajectory::getVField() {
     return vector_field;
 }
 
-// We have to delete previous waypoints if we don't want to cause memory overflow!!
-void GVF_trajectory::delete_waypoints() { 
+void GVF_trajectory::setVFiledVis(bool vis) {
+    vector_field_vis = vis;
+    vector_field->setVisible(vector_field_vis);
+
+}
+
+// We have to disconnect from dispatcher and delete previous waypoints if we don't want to cause memory overflow!!
+void GVF_trajectory::purge_trajectory() {
+    disconnect(DispatcherUi::get(), &DispatcherUi::gvf_settingUpdated, this, 0); 
+
     foreach (WaypointItem* wp, traj_waypoints) {
         assert(wp != nullptr);
         delete wp;
     }
 }
 
+// Create graphics object 
 void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
 {
     //auto color = AircraftManager::get()->getAircraft(ac_id)->getColor();
     auto color = Qt::green;
 
     traj_item = new PathItem(ac_id, color);
-    //traj_item->setClosedPath(true);
     //traj_item->setZValues(z, z);
 
     for(auto point: points) {
@@ -54,6 +60,7 @@ void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
     }
 
     traj_item->setText("AC " + ac_id + " GVF");
+    //traj_item->setVisible(traj_item_vis); (TODO)
 }
 
 void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area) 
@@ -77,4 +84,23 @@ void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoi
     //auto color = AircraftManager::get()->getAircraft(ac_id)->getColor();
     auto color = Qt::red;
     vector_field = new QuiverItem(pos, vpos, ac_id, color, 0.5);
+    vector_field->setVisible(vector_field_vis);
+}
+
+
+
+/////////////// UTILITY FUNCTIONS ///////////////
+QList<QPointF> GVF_trajectory::meshGrid(float area, int xpoints_num, int ypoints_num)
+{
+    QList<QPointF> grid;
+
+    float dx = sqrt(area)/(xpoints_num - 1);
+    float dy = sqrt(area)/(ypoints_num - 1);
+    for(float x=xy_off.x() - 0.5*sqrt(area); x<=xy_off.x() + 0.5*sqrt(area) + dx/2; x+=dx) {
+        for(float y=xy_off.y() - 0.5*sqrt(area); y<=xy_off.y() + 0.5*sqrt(area) + dy/2; y+=dy) {
+            grid.append(QPointF(x,y));
+        }
+    }
+
+    return grid;
 }

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -24,36 +24,39 @@ QList<QPointF> GVF_trajectory::meshGrid(float area, int xpoints_num, int ypoints
     return grid;
 }
 
+PathItem* GVF_trajectory::getTraj() {
+    return traj_item;
+}
+
 QuiverItem* GVF_trajectory::getVField() {
     return vector_field;
 }
 
+void GVF_trajectory::delete_waypoints() { // We have to delete this objetcs!!
+    foreach (WaypointItem* wp, traj_waypoints) {
+        assert(wp != nullptr);
+        delete wp;
+    }
+}
+
 void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
 {
-    (void)points;
-    //     auto pi = new PathItem("__NO_AC__", palette);
-    //     if(shape == 1) {    // Polygon
-    //         pi->setFilled(true);
-    //         pi->setClosedPath(true);
-    //     }
-    //     pi->setZValues(z, z);
-    //     for(auto pos: points) {
-    //         auto wi = new WaypointItem(pos, "__NO_AC__", palette);
-    //         //wcenter->setEditable(false);
-    //         //wcenter->setZValues(z, z);
-    //         addItem(wi);
-    //         wi->setStyle(GraphicsObject::Style::CURRENT_NAV);
-    //         pi->addPoint(wi);
-    //     }
-    //     pi->setText(text);
-    //     addItem(pi);
-    //     item = pi;
+    //auto color = AircraftManager::get()->getAircraft(QString::number(ac_id))->getColor();
+    auto color = Qt::green;
 
-    // }
+    traj_item = new PathItem(QString::number(ac_id), color);
+    traj_item->setClosedPath(true);
+    //traj_item->setZValues(z, z);
 
-    // if(item != nullptr && !shape_id.isNull()) {
-    //     shapes[shape_id] = item;
-    // }
+    for(auto point: points) {
+        auto pos = CoordinatesTransform::get()->ltp_to_wgs84(ltp_origin, point.x(), point.y());
+        auto wp =  new WaypointItem(pos, QString::number(ac_id), color); 
+        wp->setStyle(GraphicsObject::Style::CURRENT_NAV);
+        traj_item->addPoint(wp);
+        traj_waypoints.append(wp);
+    }
+
+    traj_item->setText("AC " + QString::number(ac_id) + " GVF");
 }
 
 void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints) 
@@ -65,6 +68,8 @@ void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoi
         pos.append(CoordinatesTransform::get()->ltp_to_wgs84(ltp_origin, points[i].x(), points[i].y()));
         vpos.append(CoordinatesTransform::get()->ltp_to_wgs84(pos[i], vpoints[i].x(), vpoints[i].y()));
     }
-
-    vector_field = new QuiverItem(pos, vpos,  QString::number(ac_id));
+    
+    //auto color = AircraftManager::get()->getAircraft(QString::number(ac_id))->getColor();
+    auto color = Qt::red;
+    vector_field = new QuiverItem(pos, vpos, QString::number(ac_id), QPen(color, 0.5));
 }

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -142,7 +142,6 @@ void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoi
         
         auto pos_latlon  = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, points[i].x(), points[i].y());
         auto vpos_latlon = CoordinatesTransform::get()->relative_utm_to_wgs84(pos_latlon, vx, vy);
-        // AQUÍ ESTÁ EL PROBLEMA!!! (en meter el pos_latlon dentro de ltp_to_wgs84)
 
         field_item->addQuiver(pos_latlon, vpos_latlon);  
     }

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -13,8 +13,8 @@ GVF_trajectory::GVF_trajectory(QString id, Point2DLatLon origin, QVector<int> *g
     field_xpts = gvfV_settings[3];
     field_ypts = gvfV_settings[4];  
 
-    field_item = new QuiverItem(ac_id, Qt::red, 0.5, this);
     traj_item = new PathItem(ac_id, Qt::green);
+    field_item = new QuiverItem(ac_id, Qt::red, 0.5, this);
 
     // If you're alive, please update your map items when gvf_viewer request it 
     connect(DispatcherUi::get(), &DispatcherUi::gvf_settingUpdated, this,
@@ -83,8 +83,8 @@ void GVF_trajectory::createTrajItem(QList<QPointF> points) // TODO
 
 void GVF_trajectory::createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float ref_field_area) 
 {  
-    // Arrows scaling based on the trajectory bounding field_area
-    float scale = sqrt(ref_field_area/field_area); 
+    // Arrows scaling based on the trajectory bounding field area, xpts and ypts
+    float scale = sqrt(ref_field_area/field_area)*sqrt(field_xpts*field_ypts/pow(24,2)); 
 
     for (int i=0; i<points.size(); i++) {
         float vx = vpoints[i].x();

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -1,0 +1,6 @@
+#include "gvf_trajectory.h"
+
+GVF_trajectory::GVF_trajectory()
+{
+    
+}

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -139,7 +139,7 @@ QPointF GVF_trajectory::getACpos() {
     }
 
     QPointF ac_xy;
-    CoordinatesTransform::get()->wgs84_to_ltp(ltp_origin, latlon, ac_xy.rx(), ac_xy.ry());
+    CoordinatesTransform::get()->wgs84_to_relative_utm(ltp_origin, latlon, ac_xy.rx(), ac_xy.ry());
 
     return ac_xy;
 }   

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -6,8 +6,8 @@
 #include "quiver_item.h"
 #include "path_item.h"
 
-constexpr int QUIVERS_NUMBER = 20;
-constexpr float DEFAULT_AREA = 1000;
+const int QUIVERS_NUMBER = 20;
+const int DEFAULT_AREA = 1000;
 
 class GVF_trajectory : public QObject
 {
@@ -36,20 +36,27 @@ protected:
 
     void createTrajItem(QList<QPointF> points);
     void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area, float ref_area = 150);
-    QList<QPointF> meshGrid(float area = DEFAULT_AREA, int xpoints_num = QUIVERS_NUMBER, int ypoints_num = QUIVERS_NUMBER);
+    QList<QPointF> meshGrid(float area = 1000, int xpoints_num = 20, int ypoints_num = 20);
+    QPointF getACpos();
 
-    virtual void param_points() = 0;
-    virtual void vector_field() = 0;
+    virtual void genTraj() = 0;
+    virtual void genVField() = 0;
 
+    // GVF viewer config (TODO)
+    float field_area;
+    int field_xpts;
+    int field_ypts;
+    
 private:
-    QObject* child;
-
     QuiverItem* field_item;
     PathItem* traj_item;
     QList<WaypointItem*> traj_waypoints;
 
+    // GVF viewer config
     bool field_item_vis;
     bool traj_item_vis;
+
+
 };
 
 #endif // GVF_TRAJECTORY_H

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -2,7 +2,9 @@
 #define GVF_TRAJECTORY_H
 
 #include "point2dlatlon.h"
+#include "AircraftManager.h"
 #include "quiver_item.h"
+#include "path_item.h"
 #include <math.h>
 #include <QPointF>
 #include <QList>
@@ -23,6 +25,10 @@ public:
     void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints);
 
     QuiverItem* getVField();
+    PathItem* getTraj();
+
+    void delete_waypoints();
+    
 protected:
     uint8_t ac_id;
     Point2DLatLon ltp_origin;
@@ -35,6 +41,8 @@ protected:
 
 private:
     QuiverItem* vector_field;
+    PathItem* traj_item;
+    QList<WaypointItem*> traj_waypoints;
 
 };
 

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -36,6 +36,7 @@ protected:
     QList<QPointF> vxy_mesh;
     
     void createTrajItem(QList<QPointF> points);
+    void createTrajItem(QList<QPointF> xy_points, QList<float> z_points);
     void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float ref_area = 500);
     QList<QPointF> meshGrid();
     QPointF getACpos();

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -13,15 +13,18 @@ class GVF_trajectory : public QObject
 {
     Q_OBJECT
 public:
-    explicit GVF_trajectory(QString id, Point2DLatLon origin, QVector<int> *gvf_settings);
+    explicit GVF_trajectory(QString id, QVector<int> *gvf_settings);
 
+    Point2DLatLon getCarrot();
     QuiverItem* getVField();
     PathItem* getTraj();
 
     void setVFiledVis(bool vis);
 
     void purge_trajectory();
-    void update_trajectory();
+    void generate_trajectory();
+    void update_VField();
+    void update_origin();
 
 protected:
     QString ac_id;
@@ -31,7 +34,7 @@ protected:
 
     QList<QPointF> xy_mesh;
     QList<QPointF> vxy_mesh;
-
+    
     void createTrajItem(QList<QPointF> points);
     void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float ref_area = 500);
     QList<QPointF> meshGrid();

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -9,10 +9,11 @@
 constexpr int QUIVERS_NUMBER = 20;
 constexpr float DEFAULT_AREA = 1000;
 
-class GVF_trajectory
+class GVF_trajectory : public QObject
 {
+    Q_OBJECT
 public:
-    GVF_trajectory(QString id, Point2DLatLon origin);
+    GVF_trajectory(QString id, Point2DLatLon origin, QList<float> gvf_settings);
 
     QList<QPointF> meshGrid(float area = DEFAULT_AREA, int xpoints_num = QUIVERS_NUMBER, int ypoints_num = QUIVERS_NUMBER);
 
@@ -22,8 +23,10 @@ public:
     QuiverItem* getVField();
     PathItem* getTraj();
 
-    void delete_waypoints();
-    
+    void setVFiledVis(bool vis);
+
+    void purge_trajectory();
+        
 protected:
     QString ac_id;
     Point2DLatLon ltp_origin;
@@ -37,6 +40,9 @@ private:
     QuiverItem* vector_field;
     PathItem* traj_item;
     QList<WaypointItem*> traj_waypoints;
+
+    bool vector_field_vis;
+    bool traj_item_vis;
 
 };
 

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -13,11 +13,7 @@ class GVF_trajectory : public QObject
 {
     Q_OBJECT
 public:
-    GVF_trajectory(QString id, Point2DLatLon origin, QList<float> gvf_settings);
-    QList<QPointF> meshGrid(float area = DEFAULT_AREA, int xpoints_num = QUIVERS_NUMBER, int ypoints_num = QUIVERS_NUMBER);
-
-    void createTrajItem(QList<QPointF> points);
-    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area, float ref_area = 150);
+    explicit GVF_trajectory(QString id, Point2DLatLon origin, QList<float> gvf_settings);
 
     QuiverItem* getVField();
     PathItem* getTraj();
@@ -25,7 +21,10 @@ public:
     void setVFiledVis(bool vis);
 
     void purge_trajectory();
-        
+    void update_trajectory();
+
+    virtual void set_param(QList<float> param, int8_t _s, float _ke) = 0;
+
 protected:
     QString ac_id;
     Point2DLatLon ltp_origin;
@@ -33,18 +32,24 @@ protected:
     QPointF traj_grad;
 
     QList<QPointF> xy_mesh;
-    QList<QPointF> vxy_mesh;  
+    QList<QPointF> vxy_mesh;
+
+    void createTrajItem(QList<QPointF> points);
+    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area, float ref_area = 150);
+    QList<QPointF> meshGrid(float area = DEFAULT_AREA, int xpoints_num = QUIVERS_NUMBER, int ypoints_num = QUIVERS_NUMBER);
+
+    virtual void param_points() = 0;
+    virtual void vector_field() = 0;
 
 private:
     QObject* child;
 
-    QuiverItem* vector_field;
+    QuiverItem* field_item;
     PathItem* traj_item;
     QList<WaypointItem*> traj_waypoints;
 
-    bool vector_field_vis;
+    bool field_item_vis;
     bool traj_item_vis;
-
 };
 
 #endif // GVF_TRAJECTORY_H

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -3,14 +3,38 @@
 
 #include "point2dlatlon.h"
 #include "quiver_item.h"
+#include <math.h>
 #include <QPointF>
+#include <QList>
+
+#include <QDebug>
+
+constexpr int QUIVERS_NUMBER = 20;
+constexpr float DEFAULT_AREA = 1000;
 
 class GVF_trajectory
 {
 public:
-    GVF_trajectory();
+    GVF_trajectory(uint8_t id, QPointF pos, Point2DLatLon origin);
+
+    QList<QPointF> meshGrid(float area = DEFAULT_AREA, int xpoints_num = QUIVERS_NUMBER, int ypoints_num = QUIVERS_NUMBER);
+
+    void createTrajItem(QList<QPointF> points);
+    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints);
+
+    QuiverItem* getVField();
+protected:
+    uint8_t ac_id;
+    Point2DLatLon ltp_origin;
+    QPointF ac_pos;
+    QPointF xy_off;
+    QPointF traj_grad;
+
+    QList<QPointF> xy_mesh;
+    QList<QPointF> vxy_mesh;  
 
 private:
+    QuiverItem* vector_field;
 
 };
 

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -1,0 +1,17 @@
+#ifndef GVF_TRAJECTORY_H
+#define GVF_TRAJECTORY_H
+
+#include "point2dlatlon.h"
+#include "quiver_item.h"
+#include <QPointF>
+
+class GVF_trajectory
+{
+public:
+    GVF_trajectory();
+
+private:
+
+};
+
+#endif // GVF_TRAJECTORY_H

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -1,7 +1,7 @@
 #ifndef GVF_TRAJECTORY_H
 #define GVF_TRAJECTORY_H
 
-#include "point2dlatlon.h"
+#include "coordinatestransform.h"
 #include "AircraftManager.h"
 #include "quiver_item.h"
 #include "path_item.h"
@@ -17,12 +17,12 @@ constexpr float DEFAULT_AREA = 1000;
 class GVF_trajectory
 {
 public:
-    GVF_trajectory(uint8_t id, QPointF pos, Point2DLatLon origin);
+    GVF_trajectory(QString id, QPointF pos, Point2DLatLon origin);
 
     QList<QPointF> meshGrid(float area = DEFAULT_AREA, int xpoints_num = QUIVERS_NUMBER, int ypoints_num = QUIVERS_NUMBER);
 
     void createTrajItem(QList<QPointF> points);
-    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints);
+    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area);
 
     QuiverItem* getVField();
     PathItem* getTraj();
@@ -30,7 +30,7 @@ public:
     void delete_waypoints();
     
 protected:
-    uint8_t ac_id;
+    QString ac_id;
     Point2DLatLon ltp_origin;
     QPointF ac_pos;
     QPointF xy_off;

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -14,11 +14,10 @@ class GVF_trajectory : public QObject
     Q_OBJECT
 public:
     GVF_trajectory(QString id, Point2DLatLon origin, QList<float> gvf_settings);
-
     QList<QPointF> meshGrid(float area = DEFAULT_AREA, int xpoints_num = QUIVERS_NUMBER, int ypoints_num = QUIVERS_NUMBER);
 
     void createTrajItem(QList<QPointF> points);
-    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area);
+    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area, float ref_area = 150);
 
     QuiverItem* getVField();
     PathItem* getTraj();
@@ -37,6 +36,8 @@ protected:
     QList<QPointF> vxy_mesh;  
 
 private:
+    QObject* child;
+
     QuiverItem* vector_field;
     PathItem* traj_item;
     QList<WaypointItem*> traj_waypoints;

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -5,11 +5,6 @@
 #include "AircraftManager.h"
 #include "quiver_item.h"
 #include "path_item.h"
-#include <math.h>
-#include <QPointF>
-#include <QList>
-
-#include <QDebug>
 
 constexpr int QUIVERS_NUMBER = 20;
 constexpr float DEFAULT_AREA = 1000;
@@ -17,7 +12,7 @@ constexpr float DEFAULT_AREA = 1000;
 class GVF_trajectory
 {
 public:
-    GVF_trajectory(QString id, QPointF pos, Point2DLatLon origin);
+    GVF_trajectory(QString id, Point2DLatLon origin);
 
     QList<QPointF> meshGrid(float area = DEFAULT_AREA, int xpoints_num = QUIVERS_NUMBER, int ypoints_num = QUIVERS_NUMBER);
 
@@ -32,7 +27,6 @@ public:
 protected:
     QString ac_id;
     Point2DLatLon ltp_origin;
-    QPointF ac_pos;
     QPointF xy_off;
     QPointF traj_grad;
 

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -1,6 +1,7 @@
 #ifndef GVF_TRAJECTORY_H
 #define GVF_TRAJECTORY_H
 
+#include <QVector3D>
 #include "coordinatestransform.h"
 #include "AircraftManager.h"
 #include "dispatcher_ui.h"
@@ -21,8 +22,6 @@ public:
 
     void purge_trajectory();
     void update_trajectory();
-
-    virtual void set_param(QList<float> param, int8_t _s, float _ke) = 0;
 
 protected:
     QString ac_id;

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -20,6 +20,7 @@ public:
     PathItem* getTraj();
 
     void setVFiledVis(bool vis);
+    void setTrajVis(bool vis);
 
     void purge_trajectory();
     void generate_trajectory();
@@ -57,8 +58,6 @@ private:
     // GVF viewer config
     bool field_item_vis;
     bool traj_item_vis;
-
-
 };
 
 #endif // GVF_TRAJECTORY_H

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.h
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.h
@@ -3,17 +3,16 @@
 
 #include "coordinatestransform.h"
 #include "AircraftManager.h"
+#include "dispatcher_ui.h"
 #include "quiver_item.h"
 #include "path_item.h"
 
-const int QUIVERS_NUMBER = 20;
-const int DEFAULT_AREA = 1000;
 
 class GVF_trajectory : public QObject
 {
     Q_OBJECT
 public:
-    explicit GVF_trajectory(QString id, Point2DLatLon origin, QList<float> gvf_settings);
+    explicit GVF_trajectory(QString id, Point2DLatLon origin, QVector<int> *gvf_settings);
 
     QuiverItem* getVField();
     PathItem* getTraj();
@@ -35,15 +34,15 @@ protected:
     QList<QPointF> vxy_mesh;
 
     void createTrajItem(QList<QPointF> points);
-    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float bound_area, float ref_area = 150);
-    QList<QPointF> meshGrid(float area = 1000, int xpoints_num = 20, int ypoints_num = 20);
+    void createVFieldItem(QList<QPointF> points, QList<QPointF> vpoints, float ref_area = 500);
+    QList<QPointF> meshGrid();
     QPointF getACpos();
 
     virtual void genTraj() = 0;
     virtual void genVField() = 0;
 
-    // GVF viewer config (TODO)
-    float field_area;
+    // GVF viewer config
+    int field_area;
     int field_xpts;
     int field_ypts;
     

--- a/src/widgets/map/map_items/CMakeLists.txt
+++ b/src/widgets/map/map_items/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/aircraft_item.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/intruder_item.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/arrow_item.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/quiver_item.cpp
 )
 
 set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/widgets/map/map_items/path_item.cpp
+++ b/src/widgets/map/map_items/path_item.cpp
@@ -40,13 +40,17 @@ PathItem::PathItem(QString ac_id, PprzPalette palette, double neutral_scale_zoom
     setZoomFactor(1.1);
 }
 
-void PathItem::addPoint(WaypointItem* wp, bool own) {
+void PathItem::addPoint(WaypointItem* wp, QColor pt_color, bool own) {
     assert(wp != nullptr);
     waypoints.append(wp);
     owned[wp] = own;
 
+    if(!pt_color.isValid()) {
+        pt_color = color;
+    } 
+
     if(waypoints.size() > 1){
-        GraphicsLine* line = new GraphicsLine(QPointF(0, 0), QPointF(0, 0), palette, line_width, this);
+        GraphicsLine* line = new GraphicsLine(QPointF(0, 0), QPointF(0, 0), pt_color, line_width, this);
         line->setIgnoreEvent(true);
 
         lines.append(line);

--- a/src/widgets/map/map_items/path_item.cpp
+++ b/src/widgets/map/map_items/path_item.cpp
@@ -40,17 +40,17 @@ PathItem::PathItem(QString ac_id, PprzPalette palette, double neutral_scale_zoom
     setZoomFactor(1.1);
 }
 
-void PathItem::addPoint(WaypointItem* wp, QColor pt_color, bool own) {
+void PathItem::addPoint(WaypointItem* wp, QColor line_color, bool own) {
     assert(wp != nullptr);
     waypoints.append(wp);
     owned[wp] = own;
 
-    if(!pt_color.isValid()) {
-        pt_color = color;
+    if(!line_color.isValid()) {
+        line_color = color;
     } 
 
     if(waypoints.size() > 1){
-        GraphicsLine* line = new GraphicsLine(QPointF(0, 0), QPointF(0, 0), pt_color, line_width, this);
+        GraphicsLine* line = new GraphicsLine(QPointF(0, 0), QPointF(0, 0), line_color, line_width, this);
         line->setIgnoreEvent(true);
 
         lines.append(line);

--- a/src/widgets/map/map_items/path_item.cpp
+++ b/src/widgets/map/map_items/path_item.cpp
@@ -236,6 +236,20 @@ void PathItem::removeFromScene(MapWidget* map) {
 
 }
 
+void PathItem::setVisible(bool vis) {
+    for(auto l:lines) {
+        l->setVisible(vis);
+    }
+
+    if(closing_line) {
+        closing_line->setVisible(vis);
+    }
+
+    if(polygon) {
+        polygon->setVisible(vis);
+    }
+}
+
 //void PathItem::setLastLineIgnoreEvents(bool ignore) {
 //    if(lines.length() > 0) {
 //        lines.last()->setIgnoreEvent(ignore);

--- a/src/widgets/map/map_items/path_item.h
+++ b/src/widgets/map/map_items/path_item.h
@@ -13,7 +13,7 @@ class PathItem : public MapItem
 public:
     explicit PathItem(QString ac_id, QColor color=QColor(), double neutral_scale_zoom = 15, QObject *parent = nullptr);
     explicit PathItem(QString ac_id, PprzPalette palette, double neutral_scale_zoom = 15, QObject *parent = nullptr);
-    void addPoint(WaypointItem* waypoint, bool own=false);
+    void addPoint(WaypointItem* waypoint, QColor pt_color=QColor(), bool own=false);
     void setClosedPath(bool closed);
     virtual void setHighlighted(bool h);
     virtual void setForbidHighlight(bool sh);

--- a/src/widgets/map/map_items/path_item.h
+++ b/src/widgets/map/map_items/path_item.h
@@ -22,6 +22,7 @@ public:
     virtual void updateGraphics(MapWidget* map, uint32_t update_event);
     virtual void removeFromScene(MapWidget* map);
     virtual void addToMap(MapWidget* mw);
+    virtual void setVisible(bool vis) ;
     void setText(QString text) {graphics_text->setPlainText(text);}
     WaypointItem* getLastWaypoint() {return waypoints.last();}
     QList<WaypointItem*> getWaypoints() {return waypoints;}

--- a/src/widgets/map/map_items/path_item.h
+++ b/src/widgets/map/map_items/path_item.h
@@ -13,7 +13,7 @@ class PathItem : public MapItem
 public:
     explicit PathItem(QString ac_id, QColor color=QColor(), double neutral_scale_zoom = 15, QObject *parent = nullptr);
     explicit PathItem(QString ac_id, PprzPalette palette, double neutral_scale_zoom = 15, QObject *parent = nullptr);
-    void addPoint(WaypointItem* waypoint, QColor pt_color=QColor(), bool own=false);
+    void addPoint(WaypointItem* waypoint, QColor line_color=QColor(), bool own=false);
     void setClosedPath(bool closed);
     virtual void setHighlighted(bool h);
     virtual void setForbidHighlight(bool sh);

--- a/src/widgets/map/map_items/quiver_item.cpp
+++ b/src/widgets/map/map_items/quiver_item.cpp
@@ -1,13 +1,9 @@
-#include "quiver_item.h"
 #include "gcs_utils.h"
 #include "mapwidget.h"
 
-#include <QtDebug>
-
-QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString ac_id,double neutral_scale_zoom, QObject *parent) :
-    MapItem(ac_id, PprzPalette(Qt::red), neutral_scale_zoom, parent),
-    latlon(pos),
-    vlatlon(vpos)
+// TODO: Se introduzca un Point2DLatLon o un QList<Point2DLatLon> (dos constructores distintos) se debe de generar una
+QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, double neutral_scale_zoom, QObject *parent) :
+    MapItem(id, PprzPalette(Qt::red), neutral_scale_zoom, parent)
 {
     auto settings = getAppSettings();
 
@@ -15,57 +11,75 @@ QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString ac_id,doub
     z_value_unhighlighted = settings.value("map/z_values/shapes").toDouble();
     z_value = z_value_unhighlighted;
 
-    CoordinatesTransform::get()->distance_azimut(latlon, vlatlon, distance, azimut);
-    graphics_quiver = new GraphicsQuiver(distance, palette, this);
-
+    double distance, azimut;
+    CoordinatesTransform::get()->distance_azimut(pos, vpos, distance, azimut);
+    auto graphics_quiver = new GraphicsQuiver(distance, palette, this);
     graphics_quiver->setZValue(z_value);
-    
+
+    graphics_quiver_l.append(graphics_quiver);
+    latlon_l.append(pos);
+    vlatlon_l.append(vpos);
+    distance_l.append(distance);
+    azimut_l.append(azimut);
+
+    setZoomFactor(1.1);
+}
+
+QuiverItem::QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString ac, double neutral_scale_zoom, QObject *parent) :
+    MapItem(ac, PprzPalette(Qt::red), neutral_scale_zoom, parent)
+{
+    auto settings = getAppSettings();
+
+    z_value_highlighted = settings.value("map/z_values/shapes").toDouble();
+    z_value_unhighlighted = settings.value("map/z_values/shapes").toDouble();
+    z_value = z_value_unhighlighted;
+
+    for (int i=0; i<pos.size(); i++) {
+        double distance, azimut;
+        CoordinatesTransform::get()->distance_azimut(pos[i], vpos[i], distance, azimut);
+        auto graphics_quiver = new GraphicsQuiver(distance, palette, this);
+        graphics_quiver->setZValue(z_value);
+
+        graphics_quiver_l.append(graphics_quiver);
+        latlon_l.append(pos[i]);
+        vlatlon_l.append(vpos[i]);
+        distance_l.append(distance);
+        azimut_l.append(azimut);
+    }
+
     setZoomFactor(1.1);
 }
 
 void QuiverItem::addToMap(MapWidget* map) {
-    map->scene()->addItem(graphics_quiver);
+    foreach (GraphicsQuiver* graphics_quiver, graphics_quiver_l) {
+        map->scene()->addItem(graphics_quiver);
+    }
 }
 
 void QuiverItem::updateGraphics(MapWidget* map, uint32_t update_event) {
     if(update_event & (UpdateEvent::ITEM_CHANGED | UpdateEvent::MAP_ZOOMED)) {
-        QPointF scene_pos = scenePoint(latlon, zoomLevel(map->zoom()), map->tileSize());
-        double size = distMeters2Tile(distance*map->tileSize(), latlon.lat(), zoomLevel(map->zoom()));
-        double scale = size/graphics_quiver->size;
+        for (int i=0; i<graphics_quiver_l.size(); i++) {
+        QPointF scene_pos = scenePoint(latlon_l[i], zoomLevel(map->zoom()), map->tileSize());
+        double size = distMeters2Tile(distance_l[i]*map->tileSize(), latlon_l[i].lat(), zoomLevel(map->zoom()));
+        double scale = size/graphics_quiver_l[i]->size;
 
-        graphics_quiver->setPos(scene_pos);
-        graphics_quiver->setScale(scale);
-        graphics_quiver->setRotation(azimut);
+        graphics_quiver_l[i]->setPos(scene_pos);
+        graphics_quiver_l[i]->setScale(scale);
+        graphics_quiver_l[i]->setRotation(azimut_l[i]);
+        }
     }
 }
 
-void QuiverItem::setPos(Point2DLatLon pos) {
-    latlon = pos;
-    CoordinatesTransform::get()->distance_azimut(latlon, vlatlon, distance, azimut);
-    emit itemChanged();
-}
-
-void QuiverItem::setVec(Point2DLatLon vpos) {
-    vlatlon = vpos;
-    CoordinatesTransform::get()->distance_azimut(latlon, vlatlon, distance, azimut);
-    emit itemChanged();
-}
-
-void QuiverItem::setPosVec(Point2DLatLon pos, Point2DLatLon vpos) {
-    latlon = pos;
-    vlatlon = vpos;
-    CoordinatesTransform::get()->distance_azimut(latlon, vlatlon, distance, azimut);
-    emit itemChanged();
-}
-
 void QuiverItem::removeFromScene(MapWidget* map) {
-    assert(graphics_quiver != nullptr);
-    map->scene()->removeItem(graphics_quiver);
-    delete graphics_quiver;
+    foreach (GraphicsQuiver* graphics_quiver, graphics_quiver_l) {
+        assert(graphics_quiver != nullptr);
+        map->scene()->removeItem(graphics_quiver);
+        delete graphics_quiver;
+    }
 }
 
 void QuiverItem::setForbidHighlight(bool fh) {
-    graphics_quiver->setForbidHighlight(fh);
+    (void)fh;
 }
 
 void QuiverItem::setEditable(bool ed) {
@@ -73,5 +87,8 @@ void QuiverItem::setEditable(bool ed) {
 }
 
 void QuiverItem::updateZValue() {
-    graphics_quiver->setZValue(z_value);
+    foreach (GraphicsQuiver* graphics_quiver, graphics_quiver_l) {
+        graphics_quiver->setZValue(z_value);
+    }
 }
+    

--- a/src/widgets/map/map_items/quiver_item.cpp
+++ b/src/widgets/map/map_items/quiver_item.cpp
@@ -4,8 +4,8 @@
 
 #include <QtDebug>
 
-QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, double neutral_scale_zoom, QObject *parent) :
-    MapItem("__NO_AC__", PprzPalette(Qt::red), neutral_scale_zoom, parent),
+QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString ac_id,double neutral_scale_zoom, QObject *parent) :
+    MapItem(ac_id, PprzPalette(Qt::red), neutral_scale_zoom, parent),
     latlon(pos),
     vlatlon(vpos)
 {
@@ -19,6 +19,7 @@ QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, double neutral_sca
     graphics_quiver = new GraphicsQuiver(distance, palette, this);
 
     graphics_quiver->setZValue(z_value);
+    
     setZoomFactor(1.1);
 }
 
@@ -38,13 +39,20 @@ void QuiverItem::updateGraphics(MapWidget* map, uint32_t update_event) {
     }
 }
 
-void QuiverItem::setPosition(Point2DLatLon pos) {
+void QuiverItem::setPos(Point2DLatLon pos) {
     latlon = pos;
     CoordinatesTransform::get()->distance_azimut(latlon, vlatlon, distance, azimut);
     emit itemChanged();
 }
 
-void QuiverItem::setVector(Point2DLatLon vpos) {
+void QuiverItem::setVec(Point2DLatLon vpos) {
+    vlatlon = vpos;
+    CoordinatesTransform::get()->distance_azimut(latlon, vlatlon, distance, azimut);
+    emit itemChanged();
+}
+
+void QuiverItem::setPosVec(Point2DLatLon pos, Point2DLatLon vpos) {
+    latlon = pos;
     vlatlon = vpos;
     CoordinatesTransform::get()->distance_azimut(latlon, vlatlon, distance, azimut);
     emit itemChanged();

--- a/src/widgets/map/map_items/quiver_item.cpp
+++ b/src/widgets/map/map_items/quiver_item.cpp
@@ -103,6 +103,12 @@ void QuiverItem::setEditable(bool ed) {
     (void)ed;
 }
 
+void QuiverItem::setVisible(bool vis) {
+    foreach (GraphicsQuiver* graphics_quiver, graphics_quiver_l) {
+        graphics_quiver->setVisible(vis);
+    }
+}
+
 void QuiverItem::updateZValue() {
     foreach (GraphicsQuiver* graphics_quiver, graphics_quiver_l) {
         graphics_quiver->setZValue(z_value);

--- a/src/widgets/map/map_items/quiver_item.cpp
+++ b/src/widgets/map/map_items/quiver_item.cpp
@@ -13,7 +13,7 @@ QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vec, double neutral_scal
     z_value = z_value_unhighlighted;
 
     // TODO: "size" y "course" vienen determinados por "pos" y "vec".
-    size = 8;
+    size = 100;
     course = 10;
 
     graphics_quiver = new GraphicsQuiver(size, palette, this);

--- a/src/widgets/map/map_items/quiver_item.cpp
+++ b/src/widgets/map/map_items/quiver_item.cpp
@@ -1,7 +1,6 @@
 #include "gcs_utils.h"
 #include "mapwidget.h"
-
-// TODO: Se introduzca un Point2DLatLon o un QList<Point2DLatLon> (dos constructores distintos) se debe de generar una
+#include "dispatcher_ui.h"
 QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor color, float width, double neutral_scale_zoom, QObject *parent) :
     MapItem(id, PprzPalette(color), neutral_scale_zoom, parent)
 {
@@ -20,11 +19,11 @@ QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor
     double distance, azimut;
     CoordinatesTransform::get()->distance_azimut(pos, vpos, distance, azimut);
 
+    graphics_quiver->setRotation(azimut);
+
     graphics_quiver_l.append(graphics_quiver);
     latlon_l.append(pos);
-    vlatlon_l.append(vpos);
-    distance_l.append(distance);
-    azimut_l.append(azimut);
+    distance_l.append(distance); 
 
     setZoomFactor(1.1);
 }
@@ -41,18 +40,18 @@ QuiverItem::QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QStr
     z_value_unhighlighted = settings.value("map/z_values/shapes").toDouble();
     z_value = z_value_unhighlighted;
 
-        for (int i=0; i<pos.size(); i++) {
+    for (int i=0; i<pos.size(); i++) {
         auto graphics_quiver = new GraphicsQuiver(palette, width, this);
         graphics_quiver->setZValue(z_value);
 
         double distance, azimut;
         CoordinatesTransform::get()->distance_azimut(pos[i], vpos[i], distance, azimut);
+        
+        graphics_quiver->setRotation(azimut);
 
         graphics_quiver_l.append(graphics_quiver);
         latlon_l.append(pos[i]);
-        vlatlon_l.append(vpos[i]);
-        distance_l.append(distance);
-        azimut_l.append(azimut);
+        distance_l.append(distance); 
     }
 
     setZoomFactor(1.1);
@@ -67,13 +66,12 @@ void QuiverItem::addToMap(MapWidget* map) {
 void QuiverItem::updateGraphics(MapWidget* map, uint32_t update_event) {
     if(update_event & (UpdateEvent::ITEM_CHANGED | UpdateEvent::MAP_ZOOMED)) {
         for (int i=0; i<graphics_quiver_l.size(); i++) {
-        QPointF scene_pos = scenePoint(latlon_l[i], zoomLevel(map->zoom()), map->tileSize());
-        auto size = distMeters2Tile(distance_l[i]*map->tileSize(), latlon_l[i].lat(), zoomLevel(map->zoom()));
-        double scale = size/graphics_quiver_l[i]->size;
+            QPointF scene_pos = scenePoint(latlon_l[i], zoomLevel(map->zoom()), map->tileSize());
+            auto size = distMeters2Tile(distance_l[i]*map->tileSize(), latlon_l[i].lat(), zoomLevel(map->zoom()));
+            double scale = size/graphics_quiver_l[i]->size;
 
-        graphics_quiver_l[i]->setPos(scene_pos);
-        graphics_quiver_l[i]->setScale(scale);
-        graphics_quiver_l[i]->setRotation(azimut_l[i]);
+            graphics_quiver_l[i]->setPos(scene_pos);
+            graphics_quiver_l[i]->setScale(scale);
         }
     }
 }

--- a/src/widgets/map/map_items/quiver_item.cpp
+++ b/src/widgets/map/map_items/quiver_item.cpp
@@ -2,19 +2,23 @@
 #include "mapwidget.h"
 
 // TODO: Se introduzca un Point2DLatLon o un QList<Point2DLatLon> (dos constructores distintos) se debe de generar una
-QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QPen pen, double neutral_scale_zoom, QObject *parent) :
-    MapItem(id, PprzPalette(pen.color()), neutral_scale_zoom, parent)
+QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor color, float width, double neutral_scale_zoom, QObject *parent) :
+    MapItem(id, PprzPalette(color), neutral_scale_zoom, parent)
 {
+    if(color.isValid()) {
+        palette = PprzPalette(color);
+    }
+    
     auto settings = getAppSettings();
-
     z_value_highlighted = settings.value("map/z_values/shapes").toDouble();
     z_value_unhighlighted = settings.value("map/z_values/shapes").toDouble();
     z_value = z_value_unhighlighted;
 
+    auto graphics_quiver = new GraphicsQuiver(palette, width, this);
+    graphics_quiver->setZValue(z_value);
+
     double distance, azimut;
     CoordinatesTransform::get()->distance_azimut(pos, vpos, distance, azimut);
-    auto graphics_quiver = new GraphicsQuiver(distance, palette, QPen(Qt::red, 3), this);
-    graphics_quiver->setZValue(z_value);
 
     graphics_quiver_l.append(graphics_quiver);
     latlon_l.append(pos);
@@ -25,20 +29,24 @@ QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QPen p
     setZoomFactor(1.1);
 }
 
-QuiverItem::QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QPen pen, double neutral_scale_zoom, QObject *parent) :
-    MapItem(id, PprzPalette(pen.color()), neutral_scale_zoom, parent)
+QuiverItem::QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QColor color, float width, double neutral_scale_zoom, QObject *parent) :
+    MapItem(id, PprzPalette(color), neutral_scale_zoom, parent)
 {
-    auto settings = getAppSettings();
+    if(color.isValid()) {
+        palette = PprzPalette(color);
+    }
 
+    auto settings = getAppSettings();
     z_value_highlighted = settings.value("map/z_values/shapes").toDouble();
     z_value_unhighlighted = settings.value("map/z_values/shapes").toDouble();
     z_value = z_value_unhighlighted;
 
-    for (int i=0; i<pos.size(); i++) {
+        for (int i=0; i<pos.size(); i++) {
+        auto graphics_quiver = new GraphicsQuiver(palette, width, this);
+        graphics_quiver->setZValue(z_value);
+
         double distance, azimut;
         CoordinatesTransform::get()->distance_azimut(pos[i], vpos[i], distance, azimut);
-        auto graphics_quiver = new GraphicsQuiver(distance, palette, pen, this);
-        graphics_quiver->setZValue(z_value);
 
         graphics_quiver_l.append(graphics_quiver);
         latlon_l.append(pos[i]);
@@ -60,7 +68,7 @@ void QuiverItem::updateGraphics(MapWidget* map, uint32_t update_event) {
     if(update_event & (UpdateEvent::ITEM_CHANGED | UpdateEvent::MAP_ZOOMED)) {
         for (int i=0; i<graphics_quiver_l.size(); i++) {
         QPointF scene_pos = scenePoint(latlon_l[i], zoomLevel(map->zoom()), map->tileSize());
-        double size = distMeters2Tile(distance_l[i]*map->tileSize(), latlon_l[i].lat(), zoomLevel(map->zoom()));
+        auto size = distMeters2Tile(distance_l[i]*map->tileSize(), latlon_l[i].lat(), zoomLevel(map->zoom()));
         double scale = size/graphics_quiver_l[i]->size;
 
         graphics_quiver_l[i]->setPos(scene_pos);
@@ -78,8 +86,17 @@ void QuiverItem::removeFromScene(MapWidget* map) {
     }
 }
 
+void QuiverItem::setHighlighted(bool sh) {
+    MapItem::setHighlighted(sh);
+    foreach (GraphicsQuiver* graphics_quiver, graphics_quiver_l) {
+        graphics_quiver->setHighlighted(sh);
+    }
+}
+
 void QuiverItem::setForbidHighlight(bool fh) {
-    (void)fh;
+    foreach (GraphicsQuiver* graphics_quiver, graphics_quiver_l) {
+        graphics_quiver->setForbidHighlight(fh);
+    }
 }
 
 void QuiverItem::setEditable(bool ed) {

--- a/src/widgets/map/map_items/quiver_item.cpp
+++ b/src/widgets/map/map_items/quiver_item.cpp
@@ -2,8 +2,8 @@
 #include "mapwidget.h"
 
 // TODO: Se introduzca un Point2DLatLon o un QList<Point2DLatLon> (dos constructores distintos) se debe de generar una
-QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, double neutral_scale_zoom, QObject *parent) :
-    MapItem(id, PprzPalette(Qt::red), neutral_scale_zoom, parent)
+QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QPen pen, double neutral_scale_zoom, QObject *parent) :
+    MapItem(id, PprzPalette(pen.color()), neutral_scale_zoom, parent)
 {
     auto settings = getAppSettings();
 
@@ -13,7 +13,7 @@ QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, double
 
     double distance, azimut;
     CoordinatesTransform::get()->distance_azimut(pos, vpos, distance, azimut);
-    auto graphics_quiver = new GraphicsQuiver(distance, palette, this);
+    auto graphics_quiver = new GraphicsQuiver(distance, palette, QPen(Qt::red, 3), this);
     graphics_quiver->setZValue(z_value);
 
     graphics_quiver_l.append(graphics_quiver);
@@ -25,8 +25,8 @@ QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, double
     setZoomFactor(1.1);
 }
 
-QuiverItem::QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString ac, double neutral_scale_zoom, QObject *parent) :
-    MapItem(ac, PprzPalette(Qt::red), neutral_scale_zoom, parent)
+QuiverItem::QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QPen pen, double neutral_scale_zoom, QObject *parent) :
+    MapItem(id, PprzPalette(pen.color()), neutral_scale_zoom, parent)
 {
     auto settings = getAppSettings();
 
@@ -37,7 +37,7 @@ QuiverItem::QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QStr
     for (int i=0; i<pos.size(); i++) {
         double distance, azimut;
         CoordinatesTransform::get()->distance_azimut(pos[i], vpos[i], distance, azimut);
-        auto graphics_quiver = new GraphicsQuiver(distance, palette, this);
+        auto graphics_quiver = new GraphicsQuiver(distance, palette, pen, this);
         graphics_quiver->setZValue(z_value);
 
         graphics_quiver_l.append(graphics_quiver);

--- a/src/widgets/map/map_items/quiver_item.cpp
+++ b/src/widgets/map/map_items/quiver_item.cpp
@@ -1,0 +1,65 @@
+#include "quiver_item.h"
+#include "gcs_utils.h"
+#include "mapwidget.h"
+
+QuiverItem::QuiverItem(Point2DLatLon pos, Point2DLatLon vec, double neutral_scale_zoom, QObject *parent) :
+    MapItem("__NO_AC__", PprzPalette(Qt::red), neutral_scale_zoom, parent),
+    latlon(pos)
+{
+    auto settings = getAppSettings();
+
+    z_value_highlighted = settings.value("map/z_values/shapes").toDouble();
+    z_value_unhighlighted = settings.value("map/z_values/shapes").toDouble();
+    z_value = z_value_unhighlighted;
+
+    // TODO: "size" y "course" vienen determinados por "pos" y "vec".
+    size = 8;
+    course = 10;
+
+    graphics_quiver = new GraphicsQuiver(size, palette, this);
+    graphics_quiver->setZValue(z_value);
+
+    setZoomFactor(1.1);
+}
+
+void QuiverItem::addToMap(MapWidget* map) {
+    map->scene()->addItem(graphics_quiver);
+}
+
+void QuiverItem::updateGraphics(MapWidget* map, uint32_t update_event) {
+    if(update_event & (UpdateEvent::ITEM_CHANGED | UpdateEvent::MAP_ZOOMED)) {
+        QPointF scene_pos = scenePoint(latlon, zoomLevel(map->zoom()), map->tileSize());
+        graphics_quiver->setPos(scene_pos);
+        double s = getScale(map->zoom(), map->scaleFactor());
+        graphics_quiver->setScale(s);
+        graphics_quiver->setRotation(course);
+    }
+}
+
+void QuiverItem::setPosition(Point2DLatLon pos) {
+    latlon = pos;
+    emit itemChanged();
+}
+
+void QuiverItem::setVector(Point2DLatLon vec) {
+    course = 10;  // TODO: "size" y "course" vienen determinados por "pos" y "vec".
+    emit itemChanged();
+}
+
+void QuiverItem::removeFromScene(MapWidget* map) {
+    assert(graphics_quiver != nullptr);
+    map->scene()->removeItem(graphics_quiver);
+    delete graphics_quiver;
+}
+
+void QuiverItem::setForbidHighlight(bool fh) {
+    graphics_quiver->setForbidHighlight(fh);
+}
+
+void QuiverItem::setEditable(bool ed) {
+    (void)ed;
+}
+
+void QuiverItem::updateZValue() {
+    graphics_quiver->setZValue(z_value);
+}

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -8,16 +8,17 @@ class QuiverItem : public MapItem
 {
     Q_OBJECT
 public:
-    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor = Qt::red, float width = 3, double neutral_scale_zoom = 15, QObject *parent = nullptr);
-    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QColor = Qt::red, float width = 3, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor = Qt::red, float width = 0.5, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QColor = Qt::red, float width = 0.5, double neutral_scale_zoom = 15, QObject *parent = nullptr);
     virtual void addToMap(MapWidget* map) override;
     virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
     virtual void removeFromScene(MapWidget* map) override;
-    virtual void setHighlighted(bool sh);
-    virtual void setForbidHighlight(bool fh);
-    virtual void setEditable(bool ed) override;
-    virtual void setVisible(bool vis);
+    virtual void setHighlighted(bool sh) override;
+    virtual void setForbidHighlight(bool fh) override;
     virtual void updateZValue() override;
+    virtual void setEditable(bool ed) override;
+
+    void setVisible(bool vis);
 
 private:
     QList<GraphicsQuiver*> graphics_quiver_l;
@@ -25,7 +26,6 @@ private:
     QList<Point2DLatLon> latlon_l;
     QList<Point2DLatLon> vlatlon_l;
     QList<double> distance_l;
-    QList<double> azimut_l;
 };
 
 #endif // QUIVERITEM_H

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -8,7 +8,8 @@ class QuiverItem : public MapItem
 {
     Q_OBJECT
 public:
-    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString ac_id = "__NO_AC__", double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, double neutral_scale_zoom = 15, QObject *parent = nullptr);
     virtual void addToMap(MapWidget* map) override;
     virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
     virtual void removeFromScene(MapWidget* map) override;
@@ -16,17 +17,13 @@ public:
     virtual void setEditable(bool ed) override;
     virtual void updateZValue() override;
 
-    void setPos(Point2DLatLon pos);
-    void setVec(Point2DLatLon vpos);
-    void setPosVec(Point2DLatLon pos, Point2DLatLon vpos);
-
 private:
-    GraphicsQuiver* graphics_quiver;
+    QList<GraphicsQuiver*> graphics_quiver_l;
 
-    Point2DLatLon latlon;
-    Point2DLatLon vlatlon;
-    double distance;
-    double azimut;
+    QList<Point2DLatLon> latlon_l;
+    QList<Point2DLatLon> vlatlon_l;
+    QList<double> distance_l;
+    QList<double> azimut_l;
 };
 
 #endif // QUIVERITEM_H

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -8,8 +8,8 @@ class QuiverItem : public MapItem
 {
     Q_OBJECT
 public:
-    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, double neutral_scale_zoom = 15, QObject *parent = nullptr);
-    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QPen pen = QPen(Qt::red, 3), double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QPen pen = QPen(Qt::red, 3), double neutral_scale_zoom = 15, QObject *parent = nullptr);
     virtual void addToMap(MapWidget* map) override;
     virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
     virtual void removeFromScene(MapWidget* map) override;
@@ -19,6 +19,7 @@ public:
 
 private:
     QList<GraphicsQuiver*> graphics_quiver_l;
+    QPen graphics_pen;
 
     QList<Point2DLatLon> latlon_l;
     QList<Point2DLatLon> vlatlon_l;

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -8,7 +8,7 @@ class QuiverItem : public MapItem
 {
     Q_OBJECT
 public:
-    QuiverItem(Point2DLatLon pos, Point2DLatLon vec, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, double neutral_scale_zoom = 15, QObject *parent = nullptr);
     virtual void addToMap(MapWidget* map) override;
     virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
     virtual void removeFromScene(MapWidget* map) override;
@@ -17,14 +17,15 @@ public:
     virtual void updateZValue() override;
 
     void setPosition(Point2DLatLon pos);
-    void setVector(Point2DLatLon vec);
+    void setVector(Point2DLatLon vpos);
 
 private:
     GraphicsQuiver* graphics_quiver;
 
     Point2DLatLon latlon;
-    double course;
-    float size;
+    Point2DLatLon vlatlon;
+    double distance;
+    double azimut;
 };
 
 #endif // QUIVERITEM_H

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -8,8 +8,8 @@ class QuiverItem : public MapItem
 {
     Q_OBJECT
 public:
-    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor = Qt::red, float width = 0.5, double neutral_scale_zoom = 15, QObject *parent = nullptr);
-    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QColor = Qt::red, float width = 0.5, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    explicit QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor = Qt::red, float width = 0.5, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    explicit QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QColor = Qt::red, float width = 0.5, double neutral_scale_zoom = 15, QObject *parent = nullptr);
     virtual void addToMap(MapWidget* map) override;
     virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
     virtual void removeFromScene(MapWidget* map) override;

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -1,0 +1,30 @@
+#ifndef QUIVERITEM_H
+#define QUIVERITEM_H
+
+#include "map_item.h"
+#include "graphics_quiver.h"
+
+class QuiverItem : public MapItem
+{
+    Q_OBJECT
+public:
+    QuiverItem(Point2DLatLon pos, Point2DLatLon vec, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    virtual void addToMap(MapWidget* map) override;
+    virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
+    virtual void removeFromScene(MapWidget* map) override;
+    virtual void setForbidHighlight(bool fh) override;
+    virtual void setEditable(bool ed) override;
+    virtual void updateZValue() override;
+
+    void setPosition(Point2DLatLon pos);
+    void setVector(Point2DLatLon vec);
+
+private:
+    GraphicsQuiver* graphics_quiver;
+
+    Point2DLatLon latlon;
+    double course;
+    float size;
+};
+
+#endif // QUIVERITEM_H

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -22,6 +22,7 @@ public:
 
     void setVisible(bool vis);
     void addQuiver(Point2DLatLon pos, Point2DLatLon vpos);
+    void removeQuivers();
 
 private:
     float pen_width;

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -16,6 +16,7 @@ public:
     virtual void setHighlighted(bool sh);
     virtual void setForbidHighlight(bool fh);
     virtual void setEditable(bool ed) override;
+    virtual void setVisible(bool vis);
     virtual void updateZValue() override;
 
 private:

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -8,7 +8,7 @@ class QuiverItem : public MapItem
 {
     Q_OBJECT
 public:
-    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString ac_id = "__NO_AC__", double neutral_scale_zoom = 15, QObject *parent = nullptr);
     virtual void addToMap(MapWidget* map) override;
     virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
     virtual void removeFromScene(MapWidget* map) override;
@@ -16,8 +16,9 @@ public:
     virtual void setEditable(bool ed) override;
     virtual void updateZValue() override;
 
-    void setPosition(Point2DLatLon pos);
-    void setVector(Point2DLatLon vpos);
+    void setPos(Point2DLatLon pos);
+    void setVec(Point2DLatLon vpos);
+    void setPosVec(Point2DLatLon pos, Point2DLatLon vpos);
 
 private:
     GraphicsQuiver* graphics_quiver;

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -8,18 +8,18 @@ class QuiverItem : public MapItem
 {
     Q_OBJECT
 public:
-    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QPen pen = QPen(Qt::red, 3), double neutral_scale_zoom = 15, QObject *parent = nullptr);
-    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QPen pen = QPen(Qt::red, 3), double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor = Qt::red, float width = 3, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QColor = Qt::red, float width = 3, double neutral_scale_zoom = 15, QObject *parent = nullptr);
     virtual void addToMap(MapWidget* map) override;
     virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
     virtual void removeFromScene(MapWidget* map) override;
-    virtual void setForbidHighlight(bool fh) override;
+    virtual void setHighlighted(bool sh);
+    virtual void setForbidHighlight(bool fh);
     virtual void setEditable(bool ed) override;
     virtual void updateZValue() override;
 
 private:
     QList<GraphicsQuiver*> graphics_quiver_l;
-    QPen graphics_pen;
 
     QList<Point2DLatLon> latlon_l;
     QList<Point2DLatLon> vlatlon_l;

--- a/src/widgets/map/map_items/quiver_item.h
+++ b/src/widgets/map/map_items/quiver_item.h
@@ -8,8 +8,10 @@ class QuiverItem : public MapItem
 {
     Q_OBJECT
 public:
-    explicit QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor = Qt::red, float width = 0.5, double neutral_scale_zoom = 15, QObject *parent = nullptr);
-    explicit QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QColor = Qt::red, float width = 0.5, double neutral_scale_zoom = 15, QObject *parent = nullptr);
+    QuiverItem(QString id, QColor = Qt::red, float width = 0.5, QObject *parent = nullptr, double neutral_scale_zoom = 15);
+    QuiverItem(Point2DLatLon pos, Point2DLatLon vpos, QString id, QColor = Qt::red, float width = 0.5, QObject *parent = nullptr, double neutral_scale_zoom = 15);
+    QuiverItem(QList<Point2DLatLon> pos, QList<Point2DLatLon> vpos, QString id, QColor = Qt::red, float width = 0.5, QObject *parent = nullptr, double neutral_scale_zoom = 15);
+
     virtual void addToMap(MapWidget* map) override;
     virtual void updateGraphics(MapWidget* map, uint32_t update_event) override;
     virtual void removeFromScene(MapWidget* map) override;
@@ -19,8 +21,10 @@ public:
     virtual void setEditable(bool ed) override;
 
     void setVisible(bool vis);
+    void addQuiver(Point2DLatLon pos, Point2DLatLon vpos);
 
 private:
+    float pen_width;
     QList<GraphicsQuiver*> graphics_quiver_l;
 
     QList<Point2DLatLon> latlon_l;

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1204,8 +1204,9 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
     uint8_t ac_id = sender.toInt();
 
     if(gvf_trajectories.contains(sender)) {
-        // TODO: decir a la clase que elimine todos los elementos gráficos!!
         removeItem(gvf_trajectories[sender]->getVField());
+        removeItem(gvf_trajectories[sender]->getTraj());
+        gvf_trajectories[sender]->delete_waypoints();
         gvf_trajectories.remove(sender);
     }
 
@@ -1236,18 +1237,9 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
         return;
     }
 
-    qDebug() << " - ON_GVF - ";  
-    qDebug() << ac_id;
-    // qDebug() << "lat0: " << latlon0.lat << "   lon0: " << latlon0.lon;
-    // qDebug() << "lat: "  << latlon.lat  << "   lon: "  << latlon.lon;
-
-    // CoordinatesTransform::get()->ltp_to_wgs84(Point2DLatLon origin, double x, double y)
-    // CoordinatesTransform::get()->wgs84_to_ltp(Point2DLatLon origin, Point2DLatLon geo, double& x, double& y)
-
     // Getting AC LTP position from WGS84 AC and origin coordinates  
     auto ac_pos = QPointF(0,0);
     CoordinatesTransform::get()->wgs84_to_ltp(latlon0, latlon, ac_pos.rx(), ac_pos.ry());
-    // qDebug() << "px: "  << ac_pos.x() << "   py: "  << ac_pos.y();
 
     // Common parser definitions
     uint8_t traj;
@@ -1272,8 +1264,9 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
             }
             case 1: { // Ellipse
                 gvf_traj = new GVF_traj_ellipse(ac_id, ac_pos, latlon0, param, direction, ke);
-                gvf_trajectories[sender] = gvf_traj;
                 addItem(gvf_traj->getVField());
+                addItem(gvf_traj->getTraj());
+                gvf_trajectories[sender] = gvf_traj;
                 break;
             }
             case 2: { // Sin

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1186,15 +1186,6 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
     // TODO: La primera vez que se reciba un mensaje de GVF de un AC se debería genera un botón sobre 
     //       dicho AC que permite activar o no el campo vectorial y las trayectorias. Gautier ya hace
     //       algo así con la lista desplegable de botones !!!
-
-    // CONSEGUIDO: Cada trayectoria y campo tiene que ir ligado a un AC_ID (SI O SI!!)
-    // CONSEGUIDO: Conocer origen wgs84.
-    // CONSEGUIDO: Conocer la posición wgs84 del AC indicado.
-    // CONSEGUIDO: Calcular la posición ltp del AC indicado.
-    // CONSEGUIDO: Extraer todos los tados necesarios usando el Ivy bus.
-    // CONSEGUIDO: Ya tenemos todos los datos necesarios, ahora queda crear pasar por un switch que seleccione la 
-    //             GVF_trajectory que hay que crear y pintar.
-    // CONSEGUIDO: Crear todas las trayectorias (tienen que llevar un campo vertorial asociado).
     
     if(!AircraftManager::get()->aircraftExists(sender)) {
         qDebug() << "GVF: AC with id" << sender << "do not exists.";
@@ -1210,7 +1201,7 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
 
     // Requesting WGS84 AC and origin coordinates  
     auto latlon0 = Point2DLatLon(0,0);
-    auto latlon = Point2DLatLon(0,0);
+    //auto latlon = Point2DLatLon(0,0); // TODO: Eliminar estas líneas comentadas si no las uso luego!! 
 
     auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(sender);
     auto origin  = ac->getFlightPlan()->getOrigin();
@@ -1223,19 +1214,19 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
         return;
     }
 
-    if(flight_param_msg) {
-    double lat,lon;
-    flight_param_msg->getField("lat" ,lat);
-    flight_param_msg->getField("long",lon);
-    latlon = Point2DLatLon(lat,lon);
-    } else {
-        qDebug() << "GVF: Can't read FLIGHT_PARAM of AC" << sender;
-        return;
-    }
+    // if(flight_param_msg) {
+    // double lat,lon;
+    // flight_param_msg->getField("lat" ,lat);
+    // flight_param_msg->getField("long",lon);
+    // latlon = Point2DLatLon(lat,lon);
+    // } else {
+    //     qDebug() << "GVF: Can't read FLIGHT_PARAM of AC" << sender;
+    //     return;
+    // }
 
     // Getting AC LTP position from WGS84 AC and origin coordinates  
-    auto ac_pos = QPointF(0,0);
-    CoordinatesTransform::get()->wgs84_to_ltp(latlon0, latlon, ac_pos.rx(), ac_pos.ry());
+    //auto ac_pos = QPointF(0,0);
+    //CoordinatesTransform::get()->wgs84_to_ltp(latlon0, ac_pos.rx(), ac_pos.ry());
 
     // Common parser definitions
     uint8_t traj;
@@ -1259,7 +1250,7 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
                 break;
             }
             case 1: { // Ellipse
-                gvf_traj = new GVF_traj_ellipse(sender, ac_pos, latlon0, param, direction, ke);
+                gvf_traj = new GVF_traj_ellipse(sender, latlon0, param, direction, ke);
                 addItem(gvf_traj->getVField());
                 addItem(gvf_traj->getTraj());
                 gvf_trajectories[sender] = gvf_traj;
@@ -1269,7 +1260,7 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
                 break;
             }
             default:
-                qDebug() << "GVF: GVF message parse received an unknown trajectory id.";
+                qDebug() << "GVF: GVF message parser received an unknown trajectory id.";
                 return;
         }
     }
@@ -1277,7 +1268,22 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
     // GVF_PARAMETRIC message parser (TODO)
     if (msg.getDefinition().getName() == "GVF_PARAMETRIC") {
         qDebug() << "GVF: GVF_PARAMETRIC trajectories are not yet implemented in PprzGCS.";
-        return;
+
+        switch(traj)
+        {   
+            case 0: {// Trefoil 2D
+                break;
+            }
+            case 1: { // Ellipse 3D
+                break;
+            }
+            case 2: { // Lissajous 3D
+                break;
+            }
+            default:
+                qDebug() << "GVF: GVF message parser received an unknown trajectory id.";
+                return;
+        }
     }
 }
 

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1227,11 +1227,8 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
     // GVF_PARAMETRIC
     else if (msg.getDefinition().getName() == "GVF_PARAMETRIC") {
         QList<float> phi = {0.0}; // Error signals
-        //float wb;
         
         msg.getField("traj", traj);
-        //msg.getField("s", direction);
-        //msg.getField("w", wb);
         msg.getField("p", param);
         msg.getField("phi", phi);
 
@@ -1241,11 +1238,11 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
                 gvf_traj = new GVF_traj_trefoil(sender, param, phi, gvf_trajectories_config[sender]);
                 break;
             }
-            case 1: { // Ellipse 3D (TODO)
+            case 1: { // Ellipse 3D
                 gvf_traj = new GVF_traj_3D_ellipse(sender, param, phi, gvf_trajectories_config[sender]);
                 break;
             }
-            case 2: { // Lissajous 3D (TODO)
+            case 2: { // Lissajous 3D
                 gvf_traj = new GVF_traj_3D_lissajous(sender, param, phi, gvf_trajectories_config[sender]);
                 break;
             }

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1177,7 +1177,7 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
     }
 
     if(gvf_trajectories.contains(sender)) {
-        //TODO: checksum... if it is the same trayectory do not delete the previous one
+        //TODO: checksum??... if it is the same trayectory do not delete the previous one
         removeItem(gvf_trajectories[sender]->getTraj());
         removeItem(gvf_trajectories[sender]->getVField());
 
@@ -1253,7 +1253,7 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
     } else {
         return;
     }
-
+    
     addItem(gvf_traj->getTraj());
     addItem(gvf_traj->getVField());
     ac_items_managers[sender]->setCurrentGVF(gvf_traj);

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -766,6 +766,10 @@ void MapWidget::removeAC(QString ac_id) {
     ac_items_managers[ac_id]->removeItems(this);
     ac_items_managers[ac_id]->deleteLater();
     ac_items_managers.remove(ac_id);
+
+    if(gvf_loaded) {
+        gvf_trajectories.remove(ac_id);
+    }
 }
 
 void MapWidget::onWaypointChanged(Waypoint* wp, QString ac_id) {

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1197,13 +1197,6 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
         msg.getField("ke", ke);
         msg.getField("p", param);
 
-        // ---- MATERIAL INTERESANTE ---- 
-        // WaypointItem* wi = dynamic_cast<WaypointItem*>(map_item);
-        // if(wi != nullptr) {
-        //     registerWaypoint(wi);
-        // }
-        // ------------------------------
-
         switch(traj)
         {   
             case 0: {// Straight line

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1220,11 +1220,11 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
     // GVF_PARAMETRIC
     else if (msg.getDefinition().getName() == "GVF_PARAMETRIC") {
         QList<float> phi = {0.0}; // Error signals
-        float wb;
+        //float wb;
         
         msg.getField("traj", traj);
-        msg.getField("s", direction);
-        msg.getField("w", wb);
+        //msg.getField("s", direction);
+        //msg.getField("w", wb);
         msg.getField("p", param);
         msg.getField("phi", phi);
 

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1113,7 +1113,6 @@ void MapWidget::onQuiver(QString sender, pprzlink::Message msg) {
     uint8_t status;
     int32_t lat, lon;
     int32_t vlat, vlon;
-    float course;
 
     msg.getField("id", id);
     msg.getField("status", status);
@@ -1121,7 +1120,6 @@ void MapWidget::onQuiver(QString sender, pprzlink::Message msg) {
     msg.getField("lon", lon);
     msg.getField("vlat", vlat);
     msg.getField("vlon", vlon);
-    msg.getField("course", course);
 
     if(id == "clean") {
         for (MapItem* quiver : quivers){

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -119,14 +119,9 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
     connect(AircraftManager::get(), &AircraftManager::waypoint_added, this, &MapWidget::onWaypointAdded);
     connect(DispatcherUi::get(), &DispatcherUi::move_waypoint_ui, this, &MapWidget::onMoveWaypointUi);
     connect(DispatcherUi::get(), &DispatcherUi::gvf_settingUpdated, this,
-        [=](QString sender, bool traj_vis, bool field_vis) {
-            delete gvf_trajectories_config[sender];
+        [=](QString sender, QVector<int>* gvfViewer_config) {
             gvf_trajectories_config.remove(sender);
-
-            auto config = new QList<float>; // Float buffer because we may need to receive numeric inputs in the future
-            config->append((int)traj_vis);
-            config->append((int)field_vis);
-            gvf_trajectories_config[sender] = config;
+            gvf_trajectories_config[sender] = gvfViewer_config;
         });  
 
     connect(  DispatcherUi::get(), &DispatcherUi::new_ac_config, this, &MapWidget::handleNewAC);
@@ -1253,15 +1248,15 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
         switch(traj)
         {   
             case 0: {// Straight line (TODO: Fix line_turn_wp1_wp2 in GVF guidance firmware)
-                gvf_traj = new GVF_traj_line(sender, latlon0, param, direction, ke, *gvf_trajectories_config[sender]);
+                gvf_traj = new GVF_traj_line(sender, latlon0, param, direction, ke, gvf_trajectories_config[sender]);
                 break;
             }
             case 1: { // Ellipse
-                gvf_traj = new GVF_traj_ellipse(sender, latlon0, param, direction, ke, *gvf_trajectories_config[sender]);
+                gvf_traj = new GVF_traj_ellipse(sender, latlon0, param, direction, ke, gvf_trajectories_config[sender]);
                 break;
             }
             case 2: { // Sin
-                gvf_traj = new GVF_traj_sin(sender, latlon0, param, direction, ke, *gvf_trajectories_config[sender]);
+                gvf_traj = new GVF_traj_sin(sender, latlon0, param, direction, ke, gvf_trajectories_config[sender]);
                 break;
             }
             default:

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -300,6 +300,9 @@ void MapWidget::configure(QDomElement ele) {
                 widget = makeLayerCombo();
             } else {
                 widget = makeWidget(this, container, name);
+                if(name == "gvf_viewer") {
+                    gvf_loaded = true;
+                }
             }
 
             auto conf = widget_ele.firstChildElement("configure");
@@ -1164,6 +1167,10 @@ void MapWidget::setAcArrowSize(int s) {
 
 void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
     
+    if(!gvf_loaded) {
+        return;
+    }
+
     if(!AircraftManager::get()->aircraftExists(sender)) {
         qDebug() << "GVF: AC with id" << sender << "do not exists.";
         return;

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1114,12 +1114,9 @@ void MapWidget::onQuiver(QString sender, pprzlink::Message msg) {
     int32_t lat, lon;
     int32_t vlat, vlon;
 
+
     msg.getField("id", id);
     msg.getField("status", status);
-    msg.getField("lat", lat);
-    msg.getField("lon", lon);
-    msg.getField("vlat", vlat);
-    msg.getField("vlon", vlon);
 
     if(id == "clean") {
         for (MapItem* quiver : quivers){
@@ -1138,10 +1135,15 @@ void MapWidget::onQuiver(QString sender, pprzlink::Message msg) {
         return;
     }
 
-    auto pos = Point2DLatLon(lat/1e7, lon/1e7);
-    auto vec = Point2DLatLon(vlat/1e7, vlon/1e7);
+    msg.getField("lat", lat);
+    msg.getField("lon", lon);
+    msg.getField("vlat", vlat);
+    msg.getField("vlon", vlon);
 
-    auto quiver = new QuiverItem(pos, vec);
+    auto pos = Point2DLatLon(lat/1e7, lon/1e7);
+    auto vpos = Point2DLatLon(vlat/1e7, vlon/1e7);
+
+    auto quiver = new QuiverItem(pos, vpos);
     addItem(quiver);
 
     quivers[id] = quiver;

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1231,15 +1231,15 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
         switch(traj)
         {   
             case 0: {// Trefoil 2D
-                gvf_traj = new GVF_traj_trefoil(sender, param, direction, phi, wb, gvf_trajectories_config[sender]);
+                gvf_traj = new GVF_traj_trefoil(sender, param, phi, gvf_trajectories_config[sender]);
                 break;
             }
             case 1: { // Ellipse 3D (TODO)
-                gvf_traj = new GVF_traj_3D_ellipse(sender, param, direction, phi, wb, gvf_trajectories_config[sender]);
+                gvf_traj = new GVF_traj_3D_ellipse(sender, param, phi, gvf_trajectories_config[sender]);
                 break;
             }
             case 2: { // Lissajous 3D (TODO)
-                gvf_traj = new GVF_traj_3D_lissajous(sender, param, direction, phi, wb, gvf_trajectories_config[sender]);
+                gvf_traj = new GVF_traj_3D_lissajous(sender, param, phi, gvf_trajectories_config[sender]);
                 break;
             }
             default:

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -15,7 +15,9 @@
 #include "lock_button.h"
 #include "papget.h"
 #include "windindicator.h"
+
 #include "gvf_trajectory.h"
+#include "gvf_viewer.h"
 
 class ACItemManager;
 class ItemEditStateMachine;
@@ -98,6 +100,7 @@ private:
     void handleNewAC(QString ac_id);
     void removeAC(QString ac_id);
     LayerCombo* makeLayerCombo();
+    void connectGVFViewer(GVFViewer* gvf_widget);
     void addWidget(QWidget* w, LockButton* button, WidgetContainer side);
     void setEditorMode();
     void registerWaypoint(WaypointItem* waypoint);
@@ -115,6 +118,7 @@ private:
     QMap<QString, MapItem*> shapes;
     QMap<QString, MapItem*> quivers;
     QMap<QString, GVF_trajectory*> gvf_trajectories;
+    QMap<QString, QList<float>*> gvf_trajectories_config;
     QMap<QString, std::pair<MapItem*, QTime>> intruders;
     QTimer* timer_intruders;
     MapItem* gcsItem;

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -15,6 +15,7 @@
 #include "lock_button.h"
 #include "papget.h"
 #include "windindicator.h"
+#include "gvf_trajectory.h"
 
 class ACItemManager;
 class ItemEditStateMachine;
@@ -113,6 +114,7 @@ private:
 
     QMap<QString, MapItem*> shapes;
     QMap<QString, MapItem*> quivers;
+    QMap<QString, GVF_trajectory*> gvf_trajectories;
     QMap<QString, std::pair<MapItem*, QTime>> intruders;
     QTimer* timer_intruders;
     MapItem* gcsItem;

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -118,7 +118,7 @@ private:
     QMap<QString, MapItem*> shapes;
     QMap<QString, MapItem*> quivers;
     QMap<QString, GVF_trajectory*> gvf_trajectories;
-    QMap<QString, QList<float>*> gvf_trajectories_config;
+    QMap<QString, QVector<int>*> gvf_trajectories_config;
     QMap<QString, std::pair<MapItem*, QTime>> intruders;
     QTimer* timer_intruders;
     MapItem* gcsItem;

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -83,6 +83,7 @@ private slots:
     void onMoveWaypointUi(Waypoint* wp, QString ac_id);
     void onShape(QString sender, pprzlink::Message msg);
     void onIntruder(QString sender, pprzlink::Message msg);
+    void onQuiver(QString sender, pprzlink::Message msg);
     void onGCSPos(pprzlink::Message msg);
 
 private:
@@ -110,6 +111,7 @@ private:
     QList<Papget*> papgets;
 
     QMap<QString, MapItem*> shapes;
+    QMap<QString, MapItem*> quivers;
     QMap<QString, std::pair<MapItem*, QTime>> intruders;
     QTimer* timer_intruders;
     MapItem* gcsItem;

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -86,7 +86,6 @@ private slots:
     void onMoveWaypointUi(Waypoint* wp, QString ac_id);
     void onShape(QString sender, pprzlink::Message msg);
     void onIntruder(QString sender, pprzlink::Message msg);
-    // void onQuiver(pprzlink::Message msg);
     void onGCSPos(pprzlink::Message msg);
     void onGVF(QString sender, pprzlink::Message msg);
 
@@ -116,7 +115,6 @@ private:
     QList<Papget*> papgets;
 
     QMap<QString, MapItem*> shapes;
-    QMap<QString, MapItem*> quivers;
     QMap<QString, GVF_trajectory*> gvf_trajectories;
     QMap<QString, QVector<int>*> gvf_trajectories_config;
     QMap<QString, std::pair<MapItem*, QTime>> intruders;
@@ -142,7 +140,6 @@ private:
 
     long shape_bind_id;
 
-    bool t = false;
     bool gvf_loaded = false;
 
     QMap<int, Point2DPseudoMercator> pms;

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -83,8 +83,9 @@ private slots:
     void onMoveWaypointUi(Waypoint* wp, QString ac_id);
     void onShape(QString sender, pprzlink::Message msg);
     void onIntruder(QString sender, pprzlink::Message msg);
-    void onQuiver(QString sender, pprzlink::Message msg);
+    void onQuiver(pprzlink::Message msg);
     void onGCSPos(pprzlink::Message msg);
+    void onGVF(QString sender, pprzlink::Message msg);
 
 private:
 

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -99,7 +99,6 @@ private:
     void handleNewAC(QString ac_id);
     void removeAC(QString ac_id);
     LayerCombo* makeLayerCombo();
-    void connectGVFViewer(GVFViewer* gvf_widget);
     void addWidget(QWidget* w, LockButton* button, WidgetContainer side);
     void setEditorMode();
     void registerWaypoint(WaypointItem* waypoint);

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -143,6 +143,7 @@ private:
     long shape_bind_id;
 
     bool t = false;
+    bool gvf_loaded = false;
 
     QMap<int, Point2DPseudoMercator> pms;
 

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -86,7 +86,7 @@ private slots:
     void onMoveWaypointUi(Waypoint* wp, QString ac_id);
     void onShape(QString sender, pprzlink::Message msg);
     void onIntruder(QString sender, pprzlink::Message msg);
-    void onQuiver(pprzlink::Message msg);
+    // void onQuiver(pprzlink::Message msg);
     void onGCSPos(pprzlink::Message msg);
     void onGVF(QString sender, pprzlink::Message msg);
 

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -142,6 +142,8 @@ private:
 
     long shape_bind_id;
 
+    bool t = false;
+
     QMap<int, Point2DPseudoMercator> pms;
 
     int _ac_arrow_size;

--- a/src/widgets/widget_utils.cpp
+++ b/src/widgets/widget_utils.cpp
@@ -14,12 +14,13 @@
 #include "plotter.h"
 #include "link_status.h"
 #include "tuple_helpers.h"
+#include "gvf_viewer.h"
 
 using ac_widgets_list = std::tuple<
     SettingsViewer, MiniStrip,
     Commands, FlightPlanViewerV2,
     GPSClassicViewer, FlightPlanEditor,
-    Plotter, LinkStatus
+    Plotter, LinkStatus, GVFViewer
 >;
 using simple_widgets_list = std::tuple<PprzMap, Pfd>;
 using containers_list = std::tuple<StackContainer, ListContainer>;
@@ -33,6 +34,7 @@ std::map<QString, size_t> AC_WIDGETS_MAP = {
     {"flight_plan_editor", tuple_element_index_v<FlightPlanEditor, ac_widgets_list>},
     {"plotter", tuple_element_index_v<Plotter, ac_widgets_list>},
     {"link_status", tuple_element_index_v<LinkStatus, ac_widgets_list>},
+    {"gvf_viewer", tuple_element_index_v<GVFViewer, ac_widgets_list>},
 };
 
 


### PR DESCRIPTION
This new PprzGCS tool allows us to paint GVF parametric trajectories and their associated vector fields.

GVF Viewer widget:
- The new GVFViewer widget class was added to the AC_WIDGETS_MAP. This way we can manage the load of the GVF Viewer tool in the layout configuration file. With this new widget, we can configure and visualize some parameters of the GVF trajectory objects. 

- The new "colorbar" basic widget allows GVF Viewer to generate an altitude color bar for GVF parametric trajectories.

- New signals were added to the DispatchetUI in order to build a connection between GVF Viewer, the map widget, and every GVF trajectory object. 
 
GVF trajectory objects and map widget modifications: 
- When a GVF or GVF_PARAMETRIC message is received and the GVF Viewer widget is loaded, the map widget calls "onGVF". This function parses the message, generates the desired GVF trajectory object linked to the AC, and deletes the previous one.

- Every trajectory has a gvf_trajectory class that generates and paints the trajectory points with the telemetry data.

- The new quiver map item allows the gvf_trajectory objects to build the vector field.

- Every point in the path map item now has an associated color. With this modification, the objects of GVF parametric trajectories can change and associate the color of the point with the altitude.

Changes in GVF firmware: https://github.com/paparazzi/paparazzi/pull/2893