### PR TITLE
predict crash location on GCS

### DIFF
--- a/src/widgets/map/acitemmanager.cpp
+++ b/src/widgets/map/acitemmanager.cpp
@@ -2,8 +2,8 @@
 
 ACItemManager::ACItemManager(QString ac_id, WaypointItem* target, AircraftItem* aircraft_item, ArrowItem* arrow, WaypointItem* crash_item, QObject* parent):
     QObject(parent),
-    ac_id(ac_id), target(target), aircraft_item(aircraft_item), crash_item(crash_item),
-    current_nav_shape(nullptr), max_dist_circle(nullptr), arrow_item(arrow), gvf_trajectory(nullptr)
+    ac_id(ac_id), target(target), aircraft_item(aircraft_item),
+    current_nav_shape(nullptr), max_dist_circle(nullptr), arrow_item(arrow), crash_item(crash_item), gvf_trajectory(nullptr)
 {
 
 }

--- a/src/widgets/map/acitemmanager.cpp
+++ b/src/widgets/map/acitemmanager.cpp
@@ -1,8 +1,8 @@
 #include "acitemmanager.h"
 
-ACItemManager::ACItemManager(QString ac_id, WaypointItem* target, AircraftItem* aircraft_item, ArrowItem* arrow, QObject* parent):
+ACItemManager::ACItemManager(QString ac_id, WaypointItem* target, AircraftItem* aircraft_item, ArrowItem* arrow, WaypointItem* crash_item, QObject* parent):
     QObject(parent),
-    ac_id(ac_id), target(target), aircraft_item(aircraft_item),
+    ac_id(ac_id), target(target), aircraft_item(aircraft_item), crash_item(crash_item),
     current_nav_shape(nullptr), max_dist_circle(nullptr), arrow_item(arrow), gvf_trajectory(nullptr)
 {
 
@@ -71,5 +71,10 @@ void ACItemManager::removeItems(MapWidget* map) {
     if(max_dist_circle) {
         map->removeItem(max_dist_circle);
         max_dist_circle = nullptr;
+    }
+
+    if(crash_item) {
+        map->removeItem(crash_item);
+        crash_item = nullptr;
     }
 }

--- a/src/widgets/map/acitemmanager.h
+++ b/src/widgets/map/acitemmanager.h
@@ -14,7 +14,7 @@ class ACItemManager: public QObject
 {
     Q_OBJECT
 public:
-    ACItemManager(QString ac_id, WaypointItem* target, AircraftItem* aircraft_item, ArrowItem* arrow_item, QObject* parent=nullptr);
+    ACItemManager(QString ac_id, WaypointItem* target, AircraftItem* aircraft_item, ArrowItem* arrow_item, WaypointItem* crash_item, QObject* parent=nullptr);
 
     void addWaypointItem(WaypointItem*);
     void addPathItem(PathItem*);
@@ -27,6 +27,7 @@ public:
     MapItem* getCurrentNavShape() {return current_nav_shape;}
     AircraftItem* getAircraftItem() {return aircraft_item;}
     ArrowItem* getArrowItem() {return arrow_item;}
+    WaypointItem* getCrashItem() {return crash_item;}
     void removeItems(MapWidget* map);
 
 private:
@@ -38,6 +39,7 @@ private:
     MapItem* current_nav_shape;
     CircleItem* max_dist_circle;
     ArrowItem* arrow_item;
+    WaypointItem* crash_item;
 
     GVF_trajectory* gvf_trajectory;
 };

--- a/src/widgets/map/graphics_objects/graphics_object.h
+++ b/src/widgets/map/graphics_objects/graphics_object.h
@@ -18,6 +18,7 @@ public:
         CARROT,
         GCS,
         DCSHOT,
+        CRASH,
     };
 
     enum Animation {

--- a/src/widgets/map/graphics_objects/graphics_point.cpp
+++ b/src/widgets/map/graphics_objects/graphics_point.cpp
@@ -97,6 +97,13 @@ void GraphicsPoint::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt
         painter->drawEllipse(QPoint(0, 0), halfSize/2, halfSize/2);
         }
         break;
+    case CRASH: {
+        // Draw a red cross with thickness 3
+        painter->setPen(QPen(QColor(255, 0, 0), 3));
+        painter->drawLine(QPoint(-halfSize/2, -halfSize/2), QPoint(halfSize/2, halfSize/2));
+        painter->drawLine(QPoint(-halfSize/2, halfSize/2), QPoint(halfSize/2, -halfSize/2));
+        }
+        break;
     }
 
 }

--- a/src/widgets/map/graphics_objects/graphics_text.cpp
+++ b/src/widgets/map/graphics_objects/graphics_text.cpp
@@ -31,6 +31,9 @@ void GraphicsText::changeFocus() {
     case DCSHOT:
         setVisible(false);
         break;
+    case CRASH:
+        setVisible(false);
+        break;
     }
 
     update();

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -114,6 +114,13 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
     connect(show_hidden_wp_action, &QAction::toggled, [=](bool show) {
         setProperty("show_hidden_waypoints", show);
     });
+
+    show_crash_prediction_action = mapMenu->addAction("Show crash prediction");
+    show_crash_prediction_action->setCheckable(true);
+    connect(show_crash_prediction_action, &QAction::toggled, [=](bool show) {
+        setProperty("show_crash_prediction", show);
+    });
+
     auto clear_shapes = mapMenu->addAction("Clear Shapes");
     connect(clear_shapes, &QAction::triggered, this, [=](){
         clearShapes();
@@ -756,6 +763,11 @@ void MapWidget::handleNewAC(QString ac_id) {
         // create crash item at dummy position
         auto crash_item = new WaypointItem(Point2DLatLon(0, 0), ac_id, 16);
         crash_item->setStyle(GraphicsObject::Style::CRASH);
+        if(!show_crash_prediction_action->isChecked()) {
+            crash_item->setSize(0);
+        } else {
+            crash_item->setSize(5);
+        }
         addItem(crash_item);
 
         ArrowItem* arrow = new ArrowItem(ac_id, 15, this);
@@ -1393,6 +1405,19 @@ void MapWidget::showHiddenWaypoints(bool state) {
                     wpi->setStyle(GraphicsPoint::Style::CURRENT_NAV);
                 }
             }
+        }
+    }
+}
+
+void MapWidget::showCrashPrediction(bool state) {
+    show_crash_prediction_action->blockSignals(true);
+    show_crash_prediction_action->setChecked(state);
+    show_crash_prediction_action->blockSignals(false);
+    for(auto &itemManager: ac_items_managers) {
+        if(state) {
+            itemManager->getCrashItem()->setSize(5*2);
+        } else {
+            itemManager->getCrashItem()->setSize(0);
         }
     }
 }

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -764,9 +764,9 @@ void MapWidget::handleNewAC(QString ac_id) {
         auto crash_item = new WaypointItem(Point2DLatLon(0, 0), ac_id, 16);
         crash_item->setStyle(GraphicsObject::Style::CRASH);
         if(!show_crash_prediction_action->isChecked()) {
-            crash_item->setSize(0);
+            crash_item->setVisible(false);
         } else {
-            crash_item->setSize(5);
+            crash_item->setVisible(true);
         }
         addItem(crash_item);
 
@@ -1415,9 +1415,9 @@ void MapWidget::showCrashPrediction(bool state) {
     show_crash_prediction_action->blockSignals(false);
     for(auto &itemManager: ac_items_managers) {
         if(state) {
-            itemManager->getCrashItem()->setSize(5*2);
+            itemManager->getCrashItem()->setVisible(true);
         } else {
-            itemManager->getCrashItem()->setSize(0);
+            itemManager->getCrashItem()->setVisible(false);
         }
     }
 }

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -91,6 +91,7 @@ private slots:
     void clearDcShots();
     void onIntruder(QString sender, pprzlink::Message msg);
     void onDcShot(QString sender, pprzlink::Message msg);
+    void onROTORCRAFT_FP(QString sender, pprzlink::Message msg);
     void onGCSPos(pprzlink::Message msg);
     void onGVF(QString sender, pprzlink::Message msg);
 
@@ -125,6 +126,7 @@ private:
     QList<WaypointItem*> dc_shots;
     QTimer* timer_intruders;
     MapItem* gcsItem;
+    MapItem* crashItem;
 
     QHBoxLayout* horizontalLayout;
 

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -42,6 +42,7 @@ class MapWidget : public Map2D, public Configurable
     Q_OBJECT
     Q_PROPERTY(int ac_arrow_size MEMBER _ac_arrow_size WRITE setAcArrowSize)
     Q_PROPERTY(bool show_hidden_waypoints WRITE showHiddenWaypoints)
+    Q_PROPERTY(bool show_crash_prediction WRITE showCrashPrediction)
 public:
     explicit MapWidget(QWidget *parent = nullptr);
 
@@ -61,6 +62,7 @@ public:
     void rotateMap(double rot);
     void setAcArrowSize(int s);
     void showHiddenWaypoints(bool state);
+    void showCrashPrediction(bool state);
 
 signals:
     void mouseMoved(QPointF scenePos);
@@ -155,6 +157,7 @@ private:
     QMenu* mapMenu;
     QMenu* menu_clear_track;
     QAction* show_hidden_wp_action;
+    QAction* show_crash_prediction_action;
 };
 
 #endif // MAPWIDGET_H

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -126,7 +126,6 @@ private:
     QList<WaypointItem*> dc_shots;
     QTimer* timer_intruders;
     MapItem* gcsItem;
-    MapItem* crashItem;
 
     QHBoxLayout* horizontalLayout;
 


### PR DESCRIPTION
I made a GCS marker to predict the ballistic crash position.

I tried to follow this commit: https://github.com/paparazzi/PprzGCS/commit/b0e1641670fddca0e3a8ce3f43ab100ba6f39a11

I had to take some time to understand the code structure, but probably I still butchered it. Right now there is only one crashItem, which would be a problem if you have multiple drones. I guess it can be done like with DCSHOT with the QList?