### PR TITLE
Add Obstacle Grid Map Visualization in GCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,3 @@ Thumbs.db
 
 # build directory for manual build
 build/
-
-.vscode/
-ext/proj-6.3.1/
-ext/pprzlinkQt
-qt-opensource-linux-x64-5.12.0.run

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ Thumbs.db
 # build directory for manual build
 build/
 
+.vscode/
+ext/proj-6.3.1/
+ext/pprzlinkQt
+qt-opensource-linux-x64-5.12.0.run

--- a/data/gvf_layout.xml
+++ b/data/gvf_layout.xml
@@ -7,7 +7,8 @@
                 <widget name="layers" icon="map_layers_normal.svg"/>
                 <widget name="commands" icon="nav.svg"/>
                 <widget name="gps_classic_viewer" icon="gps.svg"/>
-                <widget name="gvf_viewer" icon="gvf.svg"/>
+                <widget name="gvf_viewer"  icon="gvf.svg"/>
+                <widget name="grid_viewer" icon="grid.svg"/>
             </columnLeft>
             <columnRight>
                 <widget name="PFD" icon="pfd.svg"/>

--- a/data/pictures/grid.svg
+++ b/data/pictures/grid.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="4000"
+   height="2000"
+   viewBox="0 0 4000 2000"
+   id="svg2"
+   version="1.1">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 0,0 4000,0"
+       id="h0" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 0,500 4000,0"
+       id="h1" />
+    <path
+       id="h2"
+       d="m 0,1000 4000,0"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 0,1500 4000,0"
+       id="h3" />
+    <path
+       id="h4"
+       d="m 0,2000 4000,0"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 0,0 0,2000"
+       id="v0" />
+    <path
+       id="v1"
+       d="m 500,0 0,2000"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1000,0 0,2000"
+       id="v2" />
+    <path
+       id="v3"
+       d="m 1500,0 0,2000"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2000,0 0,2000"
+       id="v4" />
+    <path
+       id="v5"
+       d="m 2500,0 0,2000"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 3000,0 0,2000"
+       id="v6" />
+    <path
+       id="v7"
+       d="m 3500,0 0,2000"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4000,0 0,2000"
+       id="v8" />
+  </g>
+</svg>

--- a/data/pictures/grid.svg
+++ b/data/pictures/grid.svg
@@ -1,86 +1,42 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   width="4000"
-   height="2000"
-   viewBox="0 0 4000 2000"
-   id="svg2"
-   version="1.1">
-  <defs
-     id="defs4" />
-  <metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     id="layer1">
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 0,0 4000,0"
-       id="h0" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 0,500 4000,0"
-       id="h1" />
-    <path
-       id="h2"
-       d="m 0,1000 4000,0"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 0,1500 4000,0"
-       id="h3" />
-    <path
-       id="h4"
-       d="m 0,2000 4000,0"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 0,0 0,2000"
-       id="v0" />
-    <path
-       id="v1"
-       d="m 500,0 0,2000"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 1000,0 0,2000"
-       id="v2" />
-    <path
-       id="v3"
-       d="m 1500,0 0,2000"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 2000,0 0,2000"
-       id="v4" />
-    <path
-       id="v5"
-       d="m 2500,0 0,2000"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 3000,0 0,2000"
-       id="v6" />
-    <path
-       id="v7"
-       d="m 3500,0 0,2000"
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 4000,0 0,2000"
-       id="v8" />
-  </g>
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
+ "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
+<svg version="1.0" xmlns="http://www.w3.org/2000/svg"
+ width="513.000000pt" height="529.000000pt" viewBox="0 0 513.000000 529.000000"
+ preserveAspectRatio="xMidYMid meet">
+
+<g transform="translate(0.000000,529.000000) scale(0.100000,-0.100000)"
+fill="#000000" stroke="none">
+<path d="M2426 5019 c-95 -10 -183 -38 -297 -94 -224 -110 -359 -247 -469
+-476 -103 -216 -117 -479 -39 -755 80 -287 273 -672 528 -1054 93 -139 357
+-494 390 -524 21 -19 21 -19 42 0 32 29 295 382 389 524 255 381 449 768 530
+1058 109 385 34 745 -209 1004 -92 98 -167 156 -274 213 -184 97 -360 128
+-591 104z m296 -578 c254 -98 368 -396 241 -634 -39 -73 -136 -167 -208 -203
+-57 -28 -66 -29 -195 -29 -134 0 -136 0 -199 34 -36 18 -91 59 -123 92 -177
+177 -179 456 -3 631 50 51 142 109 204 129 49 16 221 4 283 -20z"/>
+<path d="M988 3493 c-45 -7 -74 -47 -96 -131 -54 -202 -165 -693 -158 -699 4
+-5 236 -10 516 -11 l508 -4 11 64 c6 36 11 78 11 94 0 18 -48 125 -123 275
+-68 134 -137 282 -154 329 l-31 85 -228 1 c-126 1 -241 -1 -256 -3z"/>
+<path d="M3641 3478 c-56 -147 -102 -246 -194 -428 l-109 -215 5 -70 c3 -38 8
+-77 12 -86 9 -23 138 -29 633 -29 l415 0 -7 40 c-6 40 -144 628 -165 707 -16
+57 -39 82 -86 93 -22 5 -142 10 -268 10 -227 0 -228 0 -236 -22z"/>
+<path d="M601 2123 c-30 -126 -72 -309 -95 -408 l-42 -180 550 -3 c302 -1 553
+1 558 6 10 10 139 793 132 804 -3 4 -240 8 -528 8 l-523 0 -52 -227z"/>
+<path d="M1950 1950 c-42 -263 -60 -404 -54 -410 7 -7 248 -9 675 -8 l665 3
+-67 405 c-37 223 -68 406 -68 408 -1 1 -19 2 -41 2 -37 0 -43 -4 -88 -62 -174
+-229 -404 -507 -415 -505 -12 3 -238 278 -353 430 l-105 137 -42 0 -43 0 -64
+-400z"/>
+<path d="M3410 2341 c0 -11 118 -746 126 -783 l6 -28 559 0 559 0 -5 23 c-3
+12 -43 191 -90 397 -61 271 -89 378 -102 388 -13 9 -136 12 -535 12 -298 0
+-518 -4 -518 -9z"/>
+<path d="M484 1223 c-85 -3 -92 -5 -96 -26 -3 -12 -37 -157 -76 -322 -39 -165
+-83 -358 -97 -430 -25 -121 -25 -132 -11 -162 l16 -33 575 0 c316 0 575 3 575
+8 0 4 34 220 76 480 42 261 73 476 70 480 -7 7 -889 11 -1032 5z"/>
+<path d="M1943 1223 l-112 -4 -5 -27 c-3 -15 -38 -220 -76 -457 -39 -237 -73
+-442 -76 -457 l-6 -28 892 0 892 0 -6 25 c-3 13 -40 230 -81 481 -41 251 -78
+460 -81 465 -5 8 -1066 9 -1341 2z"/>
+<path d="M3686 1223 l-88 -4 6 -52 c4 -29 38 -245 77 -481 38 -236 69 -430 69
+-432 0 -2 259 -4 575 -4 l574 0 16 30 c15 28 15 39 0 118 -12 66 -138 629
+-180 810 l-5 22 -478 -2 c-262 -1 -517 -4 -566 -5z"/>
+</g>
 </svg>

--- a/src/tools/dispatcher_ui.h
+++ b/src/tools/dispatcher_ui.h
@@ -35,6 +35,8 @@ signals:
     void gvf_settingUpdated(QString ac_id, QVector<int> *gvfViewer_config);
     void gvf_defaultFieldSettings(QString ac_id, int area, int xpts, int ypts);
     void gvf_zlimits(QString ac_id, float minz, float maxz);
+    void slamGridVisibilityChanged(bool visible);
+    void obstacleVisibilityChanged(bool visible);
 
 public slots:
 

--- a/src/tools/pprz_dispatcher.cpp
+++ b/src/tools/pprz_dispatcher.cpp
@@ -197,9 +197,17 @@ long PprzDispatcher::bind(QString msg_name, pprzlink::messageCallback_t cb) {
 }
 
 long PprzDispatcher::bind(QString msg_name, QObject* context, pprzlink::messageCallback_t cb) {
-    long ret = link->BindMessage(dict->getDefinition(msg_name), context, cb);
-    _bindIds.append(ret);
-    return ret;
+    try
+    {
+         long ret = link->BindMessage(dict->getDefinition(msg_name), context, cb);
+        _bindIds.append(ret);
+        return ret;
+    }
+    catch(const pprzlink::no_such_message& e)
+    {
+        std::cerr << e.what() << '\n';
+    }
+    return -1;
 }
 
 void PprzDispatcher::unBind(long bid) {

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/plotter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/windindicator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/link_status.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/grid_viewer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gvf_viewer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/chat.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/chat.ui

--- a/src/widgets/grid_viewer.cpp
+++ b/src/widgets/grid_viewer.cpp
@@ -11,7 +11,7 @@ GridViewer::GridViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(
     auto slam_button = new QPushButton("ON", this);
 
     auto obstacle_label = new QLabel("Obstacle Viewer", this);
-    auto obstacle_button = new QPushButton("ON", this);
+    auto obstacle_button = new QPushButton("OFF", this);
 
     grid_layout->addWidget(slam_label, 0, 0);
     grid_layout->addWidget(slam_button, 0, 1);

--- a/src/widgets/grid_viewer.cpp
+++ b/src/widgets/grid_viewer.cpp
@@ -1,0 +1,33 @@
+#include "grid_viewer.h"
+#include <QGridLayout>
+#include <QLabel>
+#include <QPushButton>
+#include "dispatcher_ui.h"
+
+GridViewer::GridViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac_id) {
+    auto grid_layout = new QGridLayout(this);
+
+    auto slam_label = new QLabel("SLAM Grid", this);
+    auto slam_button = new QPushButton("ON", this);
+
+    auto obstacle_label = new QLabel("Obstacle Viewer", this);
+    auto obstacle_button = new QPushButton("ON", this);
+
+    grid_layout->addWidget(slam_label, 0, 0);
+    grid_layout->addWidget(slam_button, 0, 1);
+
+    grid_layout->addWidget(obstacle_label, 1, 0);
+    grid_layout->addWidget(obstacle_button, 1, 1);
+
+    connect(slam_button, &QPushButton::clicked, this, [=]() {
+        bool visible = (slam_button->text() == "ON");
+        slam_button->setText(visible ? "OFF" : "ON");
+        emit DispatcherUi::get()->slamGridVisibilityChanged(!visible);
+    });
+
+    connect(obstacle_button, &QPushButton::clicked, this, [=]() {
+        bool visible = (obstacle_button->text() == "ON");
+        obstacle_button->setText(visible ? "OFF" : "ON");
+        emit DispatcherUi::get()->obstacleVisibilityChanged(!visible);
+    });
+}

--- a/src/widgets/grid_viewer.h
+++ b/src/widgets/grid_viewer.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <QWidget>
+#include <QString>
+
+class GridViewer : public QWidget {
+    Q_OBJECT
+public:
+    explicit GridViewer(QString ac_id, QWidget *parent = nullptr);
+private:
+    QString ac_id;
+};

--- a/src/widgets/map/map_items/CMakeLists.txt
+++ b/src/widgets/map/map_items/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/intruder_item.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/arrow_item.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/quiver_item.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/grid_item.cpp
 )
 
 set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/widgets/map/map_items/grid_item.cpp
+++ b/src/widgets/map/map_items/grid_item.cpp
@@ -4,9 +4,9 @@
 
 #include "mapwidget.h"
 
-GridItem::GridItem(QString id, float xmin, float ymin, float cell_w, float cell_h, int rows, int cols, QObject* parent)
+GridItem::GridItem(QString id, float xmin, float ymin, float cell_w, float cell_h, int rows, int cols, int lt, QObject* parent)
     : MapItem(id, 15, parent),
-      xmin(xmin), ymin(ymin), cell_w(cell_w), cell_h(cell_h), rows(rows), cols(cols), grid_map(nullptr)
+      xmin(xmin), ymin(ymin), cell_w(cell_w), cell_h(cell_h), rows(rows), cols(cols), lt(lt), grid_map(nullptr)
 {
     ac_id = id;
     update_origin();
@@ -81,9 +81,9 @@ void GridItem::updateCell(MapWidget* map, uint32_t update_event, int row, int co
 
     // Color según valor
     int8_t val = grid_map->value(row, col);
-    if(val > 100) {
+    if(val > lt) {
         cells[row][col]->setBrush(QBrush(Qt::red));
-    } else if(val < -100) {
+    } else if(val < -lt) {
         cells[row][col]->setBrush(QBrush(Qt::green));
     } else {
         cells[row][col]->setBrush(QBrush(Qt::gray));

--- a/src/widgets/map/map_items/grid_item.cpp
+++ b/src/widgets/map/map_items/grid_item.cpp
@@ -52,7 +52,7 @@ void GridItem::updateCell(MapWidget* map, uint32_t update_event, int row, int co
     if(!grid_map) return;
     if(row < 0 || row >= rows || col < 0 || col >= cols) return;
 
-    // Calcula el centro y esquinas de la celda
+    // Calculate the center and corners of the cell
     float rel_x = xmin + col * cell_w + cell_w/2;
     float rel_y = ymin + row * cell_h + cell_h/2;
     float rel_x1 = xmin + col * cell_w;
@@ -64,7 +64,7 @@ void GridItem::updateCell(MapWidget* map, uint32_t update_event, int row, int co
     Point2DLatLon corner1 = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, rel_x1, rel_y1);
     Point2DLatLon corner2 = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, rel_x2, rel_y2);
 
-    // Convertir a escena
+    // Convert to scene
     QPointF scene_center = scenePoint(cell_center, zoomLevel(map->zoom()), map->tileSize());
     QPointF scene1 = scenePoint(corner1, zoomLevel(map->zoom()), map->tileSize());
     QPointF scene2 = scenePoint(corner2, zoomLevel(map->zoom()), map->tileSize());
@@ -79,7 +79,7 @@ void GridItem::updateCell(MapWidget* map, uint32_t update_event, int row, int co
         height*0.95
     );
 
-    // Color según valor
+    // Color by value
     int8_t val = grid_map->value(row, col);
     if(val > lt) {
         cells[row][col]->setBrush(QBrush(Qt::red));
@@ -121,21 +121,21 @@ void GridItem::update_origin() {
 
 void GridItem::setHighlighted(bool h) {
     MapItem::setHighlighted(h);
-    // Puedes cambiar el color de las celdas si quieres destacar el grid
+    // You can change the color of the cells if you want to highlight the grid
 }
 
 void GridItem::setForbidHighlight(bool fh) {
-    // No se usa en GridItem, pero debe implementarse
+    // Not used in GridItem, but must be implemented
     (void)fh;
 }
 
 void GridItem::setEditable(bool ed) {
-    // No se usa en GridItem, pero debe implementarse
+    // Not used in GridItem, but must be implemented
     (void)ed;
 }
 
 void GridItem::updateZValue() {
-    // Actualiza el z-value de todas las celdas
+    // Update the z-value of all cells
     for (auto& row : cells)
         for (auto* cell : row)
             cell->setZValue(z_value);

--- a/src/widgets/map/map_items/grid_item.cpp
+++ b/src/widgets/map/map_items/grid_item.cpp
@@ -42,7 +42,7 @@ void GridItem::updateGraphics(MapWidget* map, uint32_t update_event) {
             float rel_x = xmin + c * cell_w + cell_w/2;
             float rel_y = ymin + r * cell_h + cell_h/2;
 
-            // Esquina superior izquierda de la celda (en metros relativos)
+            // Esquina superior izquierda de la celda
             float rel_x1 = xmin + c * cell_w;
             float rel_y1 = ymin + r * cell_h;
 
@@ -50,25 +50,11 @@ void GridItem::updateGraphics(MapWidget* map, uint32_t update_event) {
             float rel_x2 = rel_x1 + cell_w;
             float rel_y2 = rel_y1 + cell_h;
 
-            // // Convierte a lat/lon
-            // Point2DLatLon cell_center = CoordinatesTransform::get()->relative_utm_to_wgs84(
-            //     ltp_origin, rel_x, rel_y);
-            
             // Convertir a lat/lon
             Point2DLatLon cell_center = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, rel_x, rel_y);
             Point2DLatLon corner1 = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, rel_x1, rel_y1);
             Point2DLatLon corner2 = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, rel_x2, rel_y2);
 
-
-            // // Convierte a escena
-            // QPointF scene_pos = scenePoint(cell_center, zoomLevel(map->zoom()), map->tileSize());
-
-            // // Tamaño fijo en píxeles (revisar)
-            // float pixel_size = 10; 
-
-            // // Coloca el rectángulo
-            // cells[r][c]->setRect(scene_pos.x() - pixel_size/2, scene_pos.y() - pixel_size/2, pixel_size, pixel_size);
-            
             // Convertir a escena
             QPointF scene_center = scenePoint(cell_center, zoomLevel(map->zoom()), map->tileSize());
             QPointF scene1 = scenePoint(corner1, zoomLevel(map->zoom()), map->tileSize());
@@ -96,6 +82,16 @@ void GridItem::updateGraphics(MapWidget* map, uint32_t update_event) {
         }
     }
 }
+
+
+void GridItem::setVisible(bool vis) {
+    for(auto& row : cells) {
+        for(auto* cell : row) {
+            cell->setVisible(vis);
+        }
+    }
+}
+
 
 void GridItem::removeFromScene(MapWidget* map) {
     for(auto& row : cells)

--- a/src/widgets/map/map_items/grid_item.cpp
+++ b/src/widgets/map/map_items/grid_item.cpp
@@ -116,18 +116,6 @@ void GridItem::update_origin() {
     }
 }
 
-void GridItem::updateRow(int row) {
-    if(!grid_map) return;
-    for(int c = 0; c < cols; ++c) {
-        if(grid_map->value(row, c)) {
-            cells[row][c]->setBrush(QBrush(Qt::red));
-        } else {
-            cells[row][c]->setBrush(Qt::NoBrush);
-        }
-    }
-}
-
-
 void GridItem::setHighlighted(bool h) {
     MapItem::setHighlighted(h);
     // Puedes cambiar el color de las celdas si quieres destacar el grid

--- a/src/widgets/map/map_items/grid_item.cpp
+++ b/src/widgets/map/map_items/grid_item.cpp
@@ -1,0 +1,151 @@
+#include "grid_item.h"
+#include <QBrush>
+#include <QPen>
+
+#include "mapwidget.h"
+
+GridItem::GridItem(QString id, float xmin, float ymin, float cell_w, float cell_h, int rows, int cols, QObject* parent)
+    : MapItem(id, 15, parent),
+      xmin(xmin), ymin(ymin), cell_w(cell_w), cell_h(cell_h), rows(rows), cols(cols), grid_map(nullptr)
+{
+    ac_id = id;
+    update_origin();
+    if (rows <= 0 || cols <= 0) {
+        throw std::invalid_argument("Rows and cols must be positive");
+    }
+    if (cell_w <= 0 || cell_h <= 0) {
+        throw std::invalid_argument("Cell dimensions must be positive");
+    }
+    cells.resize(rows);
+    for(int r = 0; r < rows; ++r) {
+        cells[r].resize(cols);
+        for(int c = 0; c < cols; ++c) {
+            auto rect = new QGraphicsRectItem(0, 0, cell_w, cell_h);
+            rect->setPen(Qt::NoPen);
+            rect->setBrush(Qt::white);
+            cells[r][c] = rect;
+        }
+    }
+}
+
+void GridItem::addToMap(MapWidget* map) {
+    for(auto& row : cells)
+        for(auto* cell : row)
+            map->scene()->addItem(cell);
+}
+
+void GridItem::updateGraphics(MapWidget* map, uint32_t update_event) {
+    if(!grid_map) return;
+    for(int r = 0; r < rows; ++r) {
+        for(int c = 0; c < cols; ++c) {
+            // Calcula el centro de la celda en coordenadas relativas
+            float rel_x = xmin + c * cell_w + cell_w/2;
+            float rel_y = ymin + r * cell_h + cell_h/2;
+
+            // Esquina superior izquierda de la celda (en metros relativos)
+            float rel_x1 = xmin + c * cell_w;
+            float rel_y1 = ymin + r * cell_h;
+
+            // Esquina inferior derecha
+            float rel_x2 = rel_x1 + cell_w;
+            float rel_y2 = rel_y1 + cell_h;
+
+            // // Convierte a lat/lon
+            // Point2DLatLon cell_center = CoordinatesTransform::get()->relative_utm_to_wgs84(
+            //     ltp_origin, rel_x, rel_y);
+            
+            // Convertir a lat/lon
+            Point2DLatLon cell_center = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, rel_x, rel_y);
+            Point2DLatLon corner1 = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, rel_x1, rel_y1);
+            Point2DLatLon corner2 = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, rel_x2, rel_y2);
+
+
+            // // Convierte a escena
+            // QPointF scene_pos = scenePoint(cell_center, zoomLevel(map->zoom()), map->tileSize());
+
+            // // Tamaño fijo en píxeles (revisar)
+            // float pixel_size = 10; 
+
+            // // Coloca el rectángulo
+            // cells[r][c]->setRect(scene_pos.x() - pixel_size/2, scene_pos.y() - pixel_size/2, pixel_size, pixel_size);
+            
+            // Convertir a escena
+            QPointF scene_center = scenePoint(cell_center, zoomLevel(map->zoom()), map->tileSize());
+            QPointF scene1 = scenePoint(corner1, zoomLevel(map->zoom()), map->tileSize());
+            QPointF scene2 = scenePoint(corner2, zoomLevel(map->zoom()), map->tileSize());
+
+            // Calcular ancho y alto en píxeles
+            float width = std::abs(scene2.x() - scene1.x());
+            float height = std::abs(scene2.y() - scene1.y());
+            
+            // Colocar el rectángulo en la posición correcta
+            cells[r][c]->setRect(
+                scene_center.x() - width/2,
+                scene_center.y() - height/2,
+                width*0.95,
+                height*0.95
+            );
+
+
+            // Color según valor
+            if(grid_map->value(r, c)) {
+                cells[r][c]->setBrush(QBrush(Qt::red));
+            } else {
+                cells[r][c]->setBrush(QBrush(Qt::green));
+            }
+        }
+    }
+}
+
+void GridItem::removeFromScene(MapWidget* map) {
+    for(auto& row : cells)
+        for(auto* cell : row) {
+            map->scene()->removeItem(cell);
+            delete cell;
+        }
+}
+
+void GridItem::update_origin() {
+    auto ac = pprzApp()->toolbox()->aircraftManager()->getAircraft(ac_id);
+    auto origin = ac->getFlightPlan()->getOrigin();
+
+    if(origin) {
+    ltp_origin = Point2DLatLon(origin->getLat(), origin->getLon());
+    } else {
+        qDebug() << "Grid: Can't get origin waypoint from AC " << ac_id;
+    }
+}
+
+void GridItem::updateRow(int row) {
+    if(!grid_map) return;
+    for(int c = 0; c < cols; ++c) {
+        if(grid_map->value(row, c)) {
+            cells[row][c]->setBrush(QBrush(Qt::red));
+        } else {
+            cells[row][c]->setBrush(Qt::NoBrush);
+        }
+    }
+}
+
+
+void GridItem::setHighlighted(bool h) {
+    MapItem::setHighlighted(h);
+    // Puedes cambiar el color de las celdas si quieres destacar el grid
+}
+
+void GridItem::setForbidHighlight(bool fh) {
+    // No se usa en GridItem, pero debe implementarse
+    (void)fh;
+}
+
+void GridItem::setEditable(bool ed) {
+    // No se usa en GridItem, pero debe implementarse
+    (void)ed;
+}
+
+void GridItem::updateZValue() {
+    // Actualiza el z-value de todas las celdas
+    for (auto& row : cells)
+        for (auto* cell : row)
+            cell->setZValue(z_value);
+}

--- a/src/widgets/map/map_items/grid_item.cpp
+++ b/src/widgets/map/map_items/grid_item.cpp
@@ -74,10 +74,14 @@ void GridItem::updateGraphics(MapWidget* map, uint32_t update_event) {
 
 
             // Color según valor
-            if(grid_map->value(r, c)) {
+            if((grid_map->value(r, c)) > 100) {
                 cells[r][c]->setBrush(QBrush(Qt::red));
-            } else {
+            }
+            else if((grid_map->value(r, c)) < -100) {
                 cells[r][c]->setBrush(QBrush(Qt::green));
+            } 
+            else {
+                cells[r][c]->setBrush(QBrush(Qt::gray));
             }
         }
     }

--- a/src/widgets/map/map_items/grid_item.h
+++ b/src/widgets/map/map_items/grid_item.h
@@ -12,6 +12,7 @@ public:
     void setGridMap(ObstacleGridMap* map) { grid_map = map; }
     void addToMap(MapWidget* map) override;
     void updateGraphics(MapWidget* map, uint32_t update_event) override;
+    void updateCell(MapWidget* map, uint32_t update_event, int row, int col);
     void removeFromScene(MapWidget* map) override;
 
     void setVisible(bool vis);

--- a/src/widgets/map/map_items/grid_item.h
+++ b/src/widgets/map/map_items/grid_item.h
@@ -14,6 +14,7 @@ public:
     void updateGraphics(MapWidget* map, uint32_t update_event) override;
     void removeFromScene(MapWidget* map) override;
 
+    void setVisible(bool vis);
     void updateRow(int row);
 
     void setHighlighted(bool h) override;

--- a/src/widgets/map/map_items/grid_item.h
+++ b/src/widgets/map/map_items/grid_item.h
@@ -7,7 +7,7 @@
 class GridItem : public MapItem {
     Q_OBJECT
 public:
-    GridItem(QString ac_id, float xmin, float ymin, float cell_w, float cell_h, int rows, int cols, QObject* parent = nullptr);
+    GridItem(QString ac_id, float xmin, float ymin, float cell_w, float cell_h, int rows, int cols, int lt, QObject* parent = nullptr);
 
     void setGridMap(ObstacleGridMap* map) { grid_map = map; }
     void addToMap(MapWidget* map) override;
@@ -31,7 +31,7 @@ protected:
 
 private:
     float xmin, ymin, cell_w, cell_h;
-    int rows, cols;
+    int rows, cols, lt;
     ObstacleGridMap* grid_map;
     QVector<QVector<QGraphicsRectItem*>> cells;
 };

--- a/src/widgets/map/map_items/grid_item.h
+++ b/src/widgets/map/map_items/grid_item.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "map_item.h"
+#include "widgets/map/obstacle_points/obstacle_grid.h"
+#include <QGraphicsRectItem>
+
+class GridItem : public MapItem {
+    Q_OBJECT
+public:
+    GridItem(QString ac_id, float xmin, float ymin, float cell_w, float cell_h, int rows, int cols, QObject* parent = nullptr);
+
+    void setGridMap(ObstacleGridMap* map) { grid_map = map; }
+    void addToMap(MapWidget* map) override;
+    void updateGraphics(MapWidget* map, uint32_t update_event) override;
+    void removeFromScene(MapWidget* map) override;
+
+    void updateRow(int row);
+
+    void setHighlighted(bool h) override;
+    void setForbidHighlight(bool fh) override;
+    void setEditable(bool ed) override;
+    void updateZValue() override;
+
+    void update_origin();
+
+protected:
+    QString ac_id;
+    Point2DLatLon ltp_origin;
+
+private:
+    float xmin, ymin, cell_w, cell_h;
+    int rows, cols;
+    ObstacleGridMap* grid_map;
+    QVector<QVector<QGraphicsRectItem*>> cells;
+};

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1089,7 +1089,6 @@ void MapWidget::updateNavShape(pprzlink::Message msg) {
 
 }
 
-
 void MapWidget::updateAircraftItem(pprzlink::Message msg) {
     QString ac_id;
     msg.getField("ac_id", ac_id);
@@ -1115,7 +1114,6 @@ void MapWidget::updateAircraftItem(pprzlink::Message msg) {
     }
 
 }
-
 
 void MapWidget::onShape(QString sender, pprzlink::Message msg) {
     (void)sender;
@@ -1554,7 +1552,6 @@ void MapWidget::onSLAM(QString sender, pprzlink::Message msg)
         // });
     }
 }
-
 
 void MapWidget::onGridInit(QString sender, pprzlink::Message msg) {
 

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1456,9 +1456,10 @@ void MapWidget::onSLAM(QString sender, pprzlink::Message msg)
         return;
     }
 
-
     QList<float> obstacle_rel;
+    uint8_t obstacle_type;
     msg.getField("obstacle", obstacle_rel);
+    msg.getField("obstacle_type", obstacle_type);
 
     if(obstacle_rel.size() >= 2) {
         auto ac = AircraftManager::get()->getAircraft(sender);
@@ -1470,8 +1471,14 @@ void MapWidget::onSLAM(QString sender, pprzlink::Message msg)
 
         // Properties of circle
         // TODO: See the optimal colors and size
-        auto line = QColor(Qt::black);
-        auto fill = QColor(Qt::black);
+        QColor line = QColor(Qt::black);
+        QColor fill = QColor(Qt::black); // Known Obstacle
+        if (obstacle_type == 1){
+            fill = QColor(Qt::red);   // Unknown Obstacle
+            line = QColor(Qt::red);
+        }
+        // qDebug() << "Type" << obstacle_type;
+
         fill.setAlpha(150);
         auto palette = PprzPalette(line, fill);
         float size = 0.1; // radio del obstáculo en metros

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1475,7 +1475,7 @@ void MapWidget::onGVF(QString sender, pprzlink::Message msg) {
 void MapWidget::onSLAM(QString sender, pprzlink::Message msg)
 {
 
-    if(!obstacles_visible) return; // Solo pinta si está visible
+    if(!obstacles_visible) return; // Only paints if visible
 
     if(!AircraftManager::get()->aircraftExists(sender)) {
         return;
@@ -1495,7 +1495,6 @@ void MapWidget::onSLAM(QString sender, pprzlink::Message msg)
         Point2DLatLon wgs84_pos = CoordinatesTransform::get()->relative_utm_to_wgs84(ltp_origin, obstacle_rel[0], obstacle_rel[1]);
 
         // Properties of circle
-        // TODO: See the optimal colors and size
         QColor line = QColor(Qt::black);
         QColor fill = QColor(Qt::black); // Known Obstacle
         if (obstacle_type == 1){
@@ -1506,7 +1505,7 @@ void MapWidget::onSLAM(QString sender, pprzlink::Message msg)
 
         fill.setAlpha(150);
         auto palette = PprzPalette(line, fill);
-        float size = 0.1; // radio del obstáculo en metros
+        float size = 0.1; // radius in meters
 
         double z = getAppSettings().value("map/z_values/shapes").toDouble();
 
@@ -1522,7 +1521,7 @@ void MapWidget::onSLAM(QString sender, pprzlink::Message msg)
         circle->setFilled(true);
         addItem(circle);
 
-        center->setParent(circle); // para eliminar juntos
+        center->setParent(circle); // to delete together
 
         const int MAX_OBSTACLES = 200;
         if(slam_obstacles.size() >= MAX_OBSTACLES) {
@@ -1531,25 +1530,8 @@ void MapWidget::onSLAM(QString sender, pprzlink::Message msg)
             delete old.first;
         }
 
-        // Guardar el nuevo obstáculo con su tiempo de creación
+        // Save the new obstacle with its creation time
         slam_obstacles.append({circle, QDateTime::currentDateTime()});
-
-        // Eliminar tras 30 segundos (not working)
-        // QTimer::singleShot(30000, this, [=]() {
-        //     auto sc = scene();
-        //     if(circle && sc && circle->getGraphicsCircle() && circle->getGraphicsCircle()->scene() == sc) {
-        //         sc->removeItem(circle->getGraphicsCircle());
-        //     }
-
-        //     delete circle;
-
-        //     for(int i = 0; i < obstacles.size(); ++i) {
-        //         if(obstacles[i].first == circle) {
-        //             obstacles.removeAt(i);
-        //             break;
-        //         }
-        //     }
-        // });
     }
 }
 
@@ -1610,7 +1592,6 @@ void MapWidget::onGridChanges(QString sender, pprzlink::Message msg) {
     msg.getField("value", value);
 
     obstacle_grid_map->updateCell(row, column, value);
-    // grid_item->updateGraphics(this, UpdateEvent::ITEM_CHANGED);
     grid_item->updateCell(this, UpdateEvent::ITEM_CHANGED, row, column);
 
 

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1559,7 +1559,7 @@ void MapWidget::onObstacleGrid(QString sender, pprzlink::Message msg) {
     auto ac = AircraftManager::get()->getAircraft(sender);
     float cell_w, cell_h, xmin, xmax, ymin, ymax;
     uint16_t row;
-    QList<uint8_t> columns;
+    QList<int8_t> columns;
 
     msg.getField("cell_width", cell_w);
     msg.getField("cell_height", cell_h);

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1565,9 +1565,9 @@ void MapWidget::onGridInit(QString sender, pprzlink::Message msg) {
             grid_item->setGridMap(obstacle_grid_map);
             addItem(grid_item);
         } catch (const std::exception& e) {
-            qCritical() << "Error al crear GridItem:" << e.what();
+            qCritical() << "Error creating GridItem:" << e.what();
         } catch (...) {
-            qCritical() << "Error desconocido al crear GridItem";
+            qCritical() << "Unknown Error creating GridItem";
         }
     }
 

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -1660,7 +1660,8 @@ void MapWidget::onGridChanges(QString sender, pprzlink::Message msg) {
     msg.getField("value", value);
 
     obstacle_grid_map->updateCell(row, column, value);
-    grid_item->updateGraphics(this, UpdateEvent::ITEM_CHANGED);
+    // grid_item->updateGraphics(this, UpdateEvent::ITEM_CHANGED);
+    grid_item->updateCell(this, UpdateEvent::ITEM_CHANGED, row, column);
 
 
 }

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -19,6 +19,7 @@
 #include "gvf_trajectory.h"
 #include "gvf_viewer.h"
 
+
 class ACItemManager;
 class ItemEditStateMachine;
 class MapItem;
@@ -95,6 +96,7 @@ private slots:
     void onROTORCRAFT_FP(QString sender, pprzlink::Message msg);
     void onGCSPos(pprzlink::Message msg);
     void onGVF(QString sender, pprzlink::Message msg);
+    void onSLAM(QString sender, pprzlink::Message msg);
 
 private:
 

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -101,7 +101,6 @@ private slots:
     void onGCSPos(pprzlink::Message msg);
     void onGVF(QString sender, pprzlink::Message msg);
     void onSLAM(QString sender, pprzlink::Message msg);
-    void onObstacleGrid(QString sender, pprzlink::Message msg);
     void onGridInit(QString sender, pprzlink::Message msg);
     void onGridChanges(QString sender, pprzlink::Message msg);
 

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -102,6 +102,9 @@ private slots:
     void onGVF(QString sender, pprzlink::Message msg);
     void onSLAM(QString sender, pprzlink::Message msg);
     void onObstacleGrid(QString sender, pprzlink::Message msg);
+    void onGridInit(QString sender, pprzlink::Message msg);
+    void onGridChanges(QString sender, pprzlink::Message msg);
+
 
 private:
 

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -21,6 +21,7 @@
 
 #include "grid_viewer.h"
 #include "grid_item.h"
+#include "circle_item.h"
 
 
 class ACItemManager;
@@ -164,11 +165,13 @@ private:
     QAction* show_hidden_wp_action;
     QAction* show_crash_prediction_action;
 
-    QGraphicsPixmapItem* slam_grid_pixmap = nullptr;
+    // Obstacles
     GridItem* grid_item = nullptr;
     ObstacleGridMap* obstacle_grid_map = nullptr;
     QImage slam_grid_image;
     bool slam_grid_visible = true;
+    bool obstacles_visible = true;
+    QList<QPair<CircleItem*, QDateTime>> slam_obstacles;
 };
 
 #endif // MAPWIDGET_H

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -19,6 +19,9 @@
 #include "gvf_trajectory.h"
 #include "gvf_viewer.h"
 
+#include "grid_viewer.h"
+#include "grid_item.h"
+
 
 class ACItemManager;
 class ItemEditStateMachine;
@@ -97,6 +100,7 @@ private slots:
     void onGCSPos(pprzlink::Message msg);
     void onGVF(QString sender, pprzlink::Message msg);
     void onSLAM(QString sender, pprzlink::Message msg);
+    void onObstacleGrid(QString sender, pprzlink::Message msg);
 
 private:
 
@@ -159,6 +163,12 @@ private:
     QMenu* menu_clear_track;
     QAction* show_hidden_wp_action;
     QAction* show_crash_prediction_action;
+
+    QGraphicsPixmapItem* slam_grid_pixmap = nullptr;
+    GridItem* grid_item = nullptr;
+    ObstacleGridMap* obstacle_grid_map = nullptr;
+    QImage slam_grid_image;
+    bool slam_grid_visible = true;
 };
 
 #endif // MAPWIDGET_H

--- a/src/widgets/map/mapwidget.h
+++ b/src/widgets/map/mapwidget.h
@@ -172,7 +172,7 @@ private:
     ObstacleGridMap* obstacle_grid_map = nullptr;
     QImage slam_grid_image;
     bool slam_grid_visible = true;
-    bool obstacles_visible = true;
+    bool obstacles_visible = false;
     QList<QPair<CircleItem*, QDateTime>> slam_obstacles;
 };
 

--- a/src/widgets/map/obstacle_points/CMakeLists.txt
+++ b/src/widgets/map/obstacle_points/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(SOURCE
+    ${SOURCE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/obstacle_grid.cpp
+)
+
+set(INC_DIRS 
+    ${INC_DIRS} 
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set(SOURCE ${SOURCE} PARENT_SCOPE)
+set(INC_DIRS ${INC_DIRS} PARENT_SCOPE)

--- a/src/widgets/map/obstacle_points/obstacle_grid.cpp
+++ b/src/widgets/map/obstacle_points/obstacle_grid.cpp
@@ -1,4 +1,1 @@
 #include "obstacle_grid.h"
-
-
-

--- a/src/widgets/map/obstacle_points/obstacle_grid.cpp
+++ b/src/widgets/map/obstacle_points/obstacle_grid.cpp
@@ -1,0 +1,4 @@
+#include "obstacle_grid.h"
+
+
+

--- a/src/widgets/map/obstacle_points/obstacle_grid.h
+++ b/src/widgets/map/obstacle_points/obstacle_grid.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QList>
+#include <QVector>
+
+class ObstacleGridMap {
+public:
+    ObstacleGridMap(int rows, int cols)
+        : rows(rows), cols(cols), data(rows, QVector<uint8_t>(cols, 0)) {}
+
+    void updateRow(int row, const QList<uint8_t>& values) {
+        if(row < 0 || row >= rows || values.size() != cols) return;
+        for(int c = 0; c < cols; ++c) {
+            data[row][c] = values[c];
+        }
+    }
+
+    int rowCount() const { return rows; }
+    int colCount() const { return cols; }
+    uint8_t value(int r, int c) const { return data[r][c]; }
+
+private:
+    int rows, cols;
+    QVector<QVector<uint8_t>> data;
+};

--- a/src/widgets/map/obstacle_points/obstacle_grid.h
+++ b/src/widgets/map/obstacle_points/obstacle_grid.h
@@ -6,9 +6,9 @@
 class ObstacleGridMap {
 public:
     ObstacleGridMap(int rows, int cols)
-        : rows(rows), cols(cols), data(rows, QVector<uint8_t>(cols, 0)) {}
+        : rows(rows), cols(cols), data(rows, QVector<int8_t>(cols, 0)) {}
 
-    void updateRow(int row, const QList<uint8_t>& values) {
+    void updateRow(int row, const QList<int8_t>& values) {
         if(row < 0 || row >= rows || values.size() != cols) return;
         for(int c = 0; c < cols; ++c) {
             data[row][c] = values[c];
@@ -17,9 +17,9 @@ public:
 
     int rowCount() const { return rows; }
     int colCount() const { return cols; }
-    uint8_t value(int r, int c) const { return data[r][c]; }
+    int8_t value(int r, int c) const { return data[r][c]; }
 
 private:
     int rows, cols;
-    QVector<QVector<uint8_t>> data;
+    QVector<QVector<int8_t>> data;
 };

--- a/src/widgets/map/obstacle_points/obstacle_grid.h
+++ b/src/widgets/map/obstacle_points/obstacle_grid.h
@@ -15,6 +15,11 @@ public:
         }
     }
 
+    void updateCell(int row, int column, int8_t value) {
+        if(row < 0 || row >= rows) return;
+        data[row][column] = value;
+    }
+
     int rowCount() const { return rows; }
     int colCount() const { return cols; }
     int8_t value(int r, int c) const { return data[r][c]; }

--- a/src/widgets/widget_utils.cpp
+++ b/src/widgets/widget_utils.cpp
@@ -15,6 +15,8 @@
 #include "link_status.h"
 #include "tuple_helpers.h"
 #include "gvf_viewer.h"
+#include "grid_viewer.h"
+
 #include "chat.h"
 #include "checklist.h"
 
@@ -22,7 +24,7 @@ using ac_widgets_list = std::tuple<
     SettingsViewer, MiniStrip,
     Commands, FlightPlanViewerV2,
     GPSClassicViewer, FlightPlanEditor,
-    Plotter, LinkStatus, GVFViewer,
+    Plotter, LinkStatus, GVFViewer, GridViewer,
     Checklist
 >;
 using simple_widgets_list = std::tuple<PprzMap, Pfd, Chat>;
@@ -39,6 +41,7 @@ std::map<QString, size_t> AC_WIDGETS_MAP = {
     {"link_status", tuple_element_index_v<LinkStatus, ac_widgets_list>},
     {"gvf_viewer", tuple_element_index_v<GVFViewer, ac_widgets_list>},
     {"checklist", tuple_element_index_v<Checklist, ac_widgets_list>},
+    {"grid_viewer", tuple_element_index_v<GridViewer, ac_widgets_list>},
 };
 
 


### PR DESCRIPTION
This PR adds support for visualizing obstacle grid maps in PprzGCS, based on messages sent by the `obstacle_rover` module in [paparazzi/paparazzi#3510](https://github.com/paparazzi/paparazzi/pull/3510).

### Obstacle Grid Map Visualization
- Implemented a new widget to display probabilistic obstacle grid maps.
- Toggle added to enable/disable the obstacle map layer in the GCS interface.
- Dynamic obstacle rendering with support for efficient rendering of only changed cells.
- Grid initialization via `GRID_INIT` message.
- Threshold for rendering obstacles is received via telemetry.
