### PR TITLE
Added a new tab in the flightplan_viewer2 to display aircraft mission status

### DIFF
--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -1,31 +1,32 @@
 
 set(SOURCE
     ${SOURCE}
-    ${CMAKE_CURRENT_SOURCE_DIR}/strip.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ac_selector.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/settings_viewer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/pprzmap.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/pfd.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/listcontainer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/mini_strip.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/flightplan_viewerv2.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/stackcontainer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/layer_combo.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/widget_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/pprzmap.ui
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/gps_classic_viewer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/flightplaneditor.ui
-    ${CMAKE_CURRENT_SOURCE_DIR}/flightplaneditor.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/plotter.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/windindicator.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/link_status.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/grid_viewer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_viewer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/chat.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/chat.ui
     ${CMAKE_CURRENT_SOURCE_DIR}/checklist.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/checklist.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/commands.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/flightplan_viewerv2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/flightplaneditor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/flightplaneditor.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/gps_classic_viewer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/grid_viewer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gvf_viewer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/layer_combo.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/link_status.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/listcontainer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mini_strip.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mission_model.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pfd.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plotter.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pprzmap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pprzmap.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/settings_viewer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/stackcontainer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/strip.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/widget_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/windindicator.cpp
 )
 
 set(INC_DIRS ${INC_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/widgets/flightplan_viewerv2.cpp
+++ b/src/widgets/flightplan_viewerv2.cpp
@@ -14,7 +14,7 @@ FlightPlanViewerV2::FlightPlanViewerV2(QString ac_id, QWidget *parent) : QTabWid
 {
     addTab(make_blocks_tab(), "Blocks");
     addTab(new FlightPlanEditor(ac_id, this), "Details");
-    addTab(new MissionModel(ac_id, this), "Missions");
+    addTab(new MissionWidget(ac_id, this), "Missions");
 
 
     connect(AircraftManager::get()->getAircraft(ac_id)->getStatus(),

--- a/src/widgets/flightplan_viewerv2.cpp
+++ b/src/widgets/flightplan_viewerv2.cpp
@@ -7,11 +7,15 @@
 #include "gcs_utils.h"
 #include "flightplaneditor.h"
 
+#include "mission_model.h"
+
 FlightPlanViewerV2::FlightPlanViewerV2(QString ac_id, QWidget *parent) : QTabWidget(parent),
     ac_id(ac_id), current_block(0), current_stage(0), labels_stylesheet("")
 {
     addTab(make_blocks_tab(), "Blocks");
     addTab(new FlightPlanEditor(ac_id, this), "Details");
+    addTab(new MissionModel(ac_id, this), "Missions");
+
 
     connect(AircraftManager::get()->getAircraft(ac_id)->getStatus(),
             &AircraftStatus::nav_status, this, &FlightPlanViewerV2::handleNavStatus);

--- a/src/widgets/mission_model.cpp
+++ b/src/widgets/mission_model.cpp
@@ -88,6 +88,9 @@ MissionModel::MissionModel(QString ac_id, QWidget *parent) : QTreeWidget(parent)
                 active_missions.insert(mission_id);
             } });
     }
+
+    PprzDispatcher::get()->bind("MISSION_UPDATE", this, [=,this]([[maybe_unused]] QString sender, pprzlink::Message msg)
+        {this->handleMissionUpdate(sender,msg);});
 }
 
 void MissionModel::updateActiveMissions(float remaining_time, const QList<uint8_t> &missions)
@@ -134,4 +137,27 @@ void MissionModel::updateActiveMissions(float remaining_time, const QList<uint8_
     active_missions_count = rank;
     this->sortItems(0, Qt::AscendingOrder);
     active_missions = new_active_missions;
+}
+
+void MissionModel::handleMissionUpdate([[maybe_unused]] QString sender, const pprzlink::Message &msg)
+{
+    uint8_t dest_id;
+    msg.getField("ac_id", dest_id);
+    if (QString::number(dest_id) == ac_id)
+    {
+        uint8_t mission_id;
+        msg.getField("index", mission_id);
+        if (!this->missions.contains(mission_id)) {return;} // Cannot update unknown mission
+
+        MissionInfo *info = this->missions[mission_id];
+        if (info->getType() != "MISSION_CUSTOM") {return;} // As of 2026-04-23, MISSION_UPDATE affects only the MISSION_CUSTOM type (and not the standard ones)
+        float duration;
+        msg.getField("duration", duration);
+        if (duration > -9.f) // For duration set to -9 in update, the duration should not be changed
+        {
+            info->setDuration(duration);
+        }
+
+        info->setFieldValueTxt("params",msg.getFieldAsStr("params"));
+    }
 }

--- a/src/widgets/mission_model.cpp
+++ b/src/widgets/mission_model.cpp
@@ -1,0 +1,100 @@
+#include "mission_model.h"
+
+MissionModel::MissionModel(QString ac_id, QWidget *parent) : QTreeWidget(parent), ac_id(ac_id)
+{
+    auto charWidth = this->fontMetrics().averageCharWidth();
+
+    this->setColumnCount(4);
+    this->setHeaderLabels({"Index", "Name", "Id/Value", "Duration (s)"});
+    this->resizeColumnToContents(0);
+    this->setColumnWidth(1, charWidth * 18); // Set name column width to fit "MISSION_GOTO_WP_LLA" (trial and error guessed value)
+    this->setColumnWidth(2, charWidth * 20); // Set value column width
+    this->resizeColumnToContents(3); 
+    this->sortItems(0, Qt::AscendingOrder);
+
+    PprzDispatcher::get()->bind("MISSION_STATUS", this, [=,this](QString sender, pprzlink::Message msg)
+    {
+        if(sender == ac_id) 
+        {
+            float remaining_time;
+            QList<uint8_t> index_list;
+
+            msg.getField("remaining_time", remaining_time);
+            msg.getField("index_list", index_list);
+
+            this->updateActiveMissions(remaining_time, index_list);
+        } });
+
+    for(auto& name : MISSION_MSG_NAMES)
+    {
+        PprzDispatcher::get()->bind(name, this, [=,this]([[maybe_unused]] QString sender, pprzlink::Message msg)
+        {
+            uint8_t dest_id;
+            msg.getField("ac_id", dest_id);
+            if(QString::number(dest_id) == ac_id) 
+            {
+                uint8_t mission_id;
+                msg.getField("index", mission_id);
+                if(this->missions.contains(mission_id))
+                {
+                    MissionInfo *info = this->missions[mission_id];
+                    info->setMissionDefinitionMessage(msg);
+                } 
+                else
+                {
+                    MissionInfo* info = new MissionInfo(this,mission_id, active_missions_count, msg);
+                    this->missions[mission_id] = info;
+                    active_missions_count++;
+                    this->addTopLevelItem(info->getMainItem());
+                }
+                active_missions.insert(mission_id);
+            } 
+        });
+    }
+}
+
+void MissionModel::updateActiveMissions(float remaining_time, const QList<uint8_t> &missions)
+{
+    QSet<uint8_t> new_active_missions(missions.constBegin(), missions.constEnd());
+
+    QSet<uint8_t> deactivated_missions = active_missions - new_active_missions;
+
+    for (uint8_t mission_id : deactivated_missions)
+    {
+        if (this->missions.contains(mission_id))
+        {
+            MissionInfo *info = this->missions[mission_id];
+            info->setActive(false);
+        }
+    }
+
+    uint8_t rank = 0;
+    for (uint8_t mission_id : missions)
+    {
+        if (this->missions.contains(mission_id))
+        {
+            MissionInfo *info = this->missions[mission_id];
+            info->setActive(true);
+            info->setRank(rank);
+            if (rank == 0)
+            {
+                info->setDuration(remaining_time);
+            }
+        }
+        else
+        {
+            MissionInfo *info = new MissionInfo(this, mission_id, rank);
+            info->setActive(true);
+            this->missions[mission_id] = info;
+            if (rank == 0)
+            {
+                info->setDuration(remaining_time);
+            }
+            this->addTopLevelItem(info->getMainItem());
+        }
+        rank++;
+    }
+    active_missions_count = rank;
+    this->sortItems(0, Qt::AscendingOrder);
+    active_missions = new_active_missions;
+}

--- a/src/widgets/mission_model.cpp
+++ b/src/widgets/mission_model.cpp
@@ -1,18 +1,56 @@
 #include "mission_model.h"
 
+void MissionInfo::setupGotoButton(MissionModel *parent)
+{
+    QPushButton *goto_button = new QPushButton("GOTO", parent);
+    goto_button->setIcon(parent->style()->standardIcon(QStyle::SP_ArrowLeft));
+    goto_button->setToolTip("Set this mission as first");
+    goto_button->connect(goto_button, &QPushButton::clicked, [=, this]()
+    {
+        auto goto_definition = PprzDispatcher::get()->getDict()->getDefinition("GOTO_MISSION");
+        pprzlink::Message msg(goto_definition);
+        msg.addField("ac_id", parent->ac_id.toUInt());
+        msg.addField("mission_id", id);
+        PprzDispatcher::get()->sendMessage(msg);
+    });
+
+    parent->setItemWidget(main_item, 4, goto_button);
+}
+
+MissionInfo::MissionInfo(MissionModel *parent, uint8_t _id, uint8_t _rank)
+: id(_id), rank(_rank)
+{
+    main_item = new QTreeWidgetItem(parent);
+    main_item->setText(0, QString::number(rank));
+    main_item->setText(1, "UNKNOWN");
+    main_item->setText(2, QString::number(id));
+    main_item->setText(3, "--");
+    setupGotoButton(parent);
+}
+
+MissionInfo::MissionInfo(MissionModel *parent, uint8_t _id, uint8_t _rank, pprzlink::Message _mission_definition_message)
+: id(_id), rank(_rank), mission_definition_message(_mission_definition_message)
+{
+    main_item = new QTreeWidgetItem(parent);
+    main_item->setText(0, QString::number(rank));
+    main_item->setText(2, QString::number(id));
+    setMissionDefinitionMessage(_mission_definition_message);
+    setupGotoButton(parent);
+}
+
 MissionModel::MissionModel(QString ac_id, QWidget *parent) : QTreeWidget(parent), ac_id(ac_id)
 {
     auto charWidth = this->fontMetrics().averageCharWidth();
 
-    this->setColumnCount(4);
-    this->setHeaderLabels({"Index", "Name", "Id/Value", "Duration (s)"});
+    this->setColumnCount(5);
+    this->setHeaderLabels({"Rank", "Name", "Id/Value", "Time (s)", ""});
     this->resizeColumnToContents(0);
     this->setColumnWidth(1, charWidth * 18); // Set name column width to fit "MISSION_GOTO_WP_LLA" (trial and error guessed value)
-    this->setColumnWidth(2, charWidth * 20); // Set value column width
-    this->resizeColumnToContents(3); 
+    this->setColumnWidth(2, charWidth * 15); // Set value column width
+    this->resizeColumnToContents(3);
     this->sortItems(0, Qt::AscendingOrder);
 
-    PprzDispatcher::get()->bind("MISSION_STATUS", this, [=,this](QString sender, pprzlink::Message msg)
+    PprzDispatcher::get()->bind("MISSION_STATUS", this, [=, this](QString sender, pprzlink::Message msg)
     {
         if(sender == ac_id) 
         {
@@ -25,10 +63,10 @@ MissionModel::MissionModel(QString ac_id, QWidget *parent) : QTreeWidget(parent)
             this->updateActiveMissions(remaining_time, index_list);
         } });
 
-    for(auto& name : MISSION_MSG_NAMES)
+    for (auto &name : MISSION_MSG_NAMES)
     {
-        PprzDispatcher::get()->bind(name, this, [=,this]([[maybe_unused]] QString sender, pprzlink::Message msg)
-        {
+        PprzDispatcher::get()->bind(name, this, [=, this]([[maybe_unused]] QString sender, pprzlink::Message msg)
+                                    {
             uint8_t dest_id;
             msg.getField("ac_id", dest_id);
             if(QString::number(dest_id) == ac_id) 
@@ -48,8 +86,7 @@ MissionModel::MissionModel(QString ac_id, QWidget *parent) : QTreeWidget(parent)
                     this->addTopLevelItem(info->getMainItem());
                 }
                 active_missions.insert(mission_id);
-            } 
-        });
+            } });
     }
 }
 

--- a/src/widgets/mission_model.h
+++ b/src/widgets/mission_model.h
@@ -1,0 +1,155 @@
+#ifndef MISSION_MODEL_H
+#define MISSION_MODEL_H
+
+#include <QtWidgets>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <block.h>
+#include <memory>
+#include <functional>
+#include <optional>
+#include <array>
+#include "pprz_dispatcher.h"
+
+static const std::array<QString, 9> MISSION_MSG_NAMES = {
+        "MISSION_GOTO_WP",
+        "MISSION_GOTO_WP_LLA",
+        "MISSION_CIRCLE",
+        "MISSION_CIRCLE_LLA",
+        "MISSION_SEGMENT",
+        "MISSION_SEGMENT_LLA",
+        "MISSION_PATH",
+        "MISSION_PATH_LLA",
+        "MISSION_CUSTOM"
+    };
+
+class MissionInfo
+{
+private:
+    uint8_t id,rank;
+    optional<float> duration = nullopt;
+    optional<pprzlink::Message> mission_definition_message = nullopt;
+    bool active = false;
+
+    QTreeWidgetItem* main_item;
+    QMap<QString, QTreeWidgetItem*> details = QMap<QString, QTreeWidgetItem*>();
+public:
+    // ----- Constructors -----
+    MissionInfo() = delete;
+    MissionInfo(QTreeWidget* parent, uint8_t _id, uint8_t _rank) : id(_id), rank(_rank)
+    {
+        main_item = new QTreeWidgetItem(parent);
+        main_item->setText(0, QString::number(rank));
+        main_item->setText(1, "UNKNOWN");
+        main_item->setText(2, QString::number(id));
+        main_item->setText(3, "--");
+    }
+    MissionInfo(QTreeWidget* parent, uint8_t _id, uint8_t _rank, pprzlink::Message _mission_definition_message) :
+        id(_id), rank(_rank), mission_definition_message(_mission_definition_message)
+    {
+        main_item = new QTreeWidgetItem(parent);
+        main_item->setText(0, QString::number(rank));
+        main_item->setText(2, QString::number(id));
+        setMissionDefinitionMessage(_mission_definition_message);
+    }
+
+    // ----- Getters -----
+    uint8_t getId() const { return id; }
+    uint8_t getRank() const { return rank; }
+    optional<float> getDuration() const { return duration; }
+    optional<pprzlink::Message> getMissionDefinitionMessage() const { return mission_definition_message; }
+    bool isActive() const { return active; }
+
+    QTreeWidgetItem* getMainItem() const
+    {
+        return main_item;
+    }
+
+    // ----- Setters -----
+    void setRank(uint8_t _rank)
+    {
+        rank = _rank;
+        main_item->setText(0, QString::number(rank));
+    }
+
+    void setName(const QString& name)
+    {
+        main_item->setText(1, name);
+    }
+
+    void setId(uint8_t _id)
+    {
+        id = _id;
+        main_item->setText(2, QString::number(id));
+    }
+
+    void setDuration(float _duration)
+    {   
+        duration = _duration;
+        main_item->setText(3, QString::number(_duration, 'f', 3));
+    }
+
+    void setMissionDefinitionMessage(pprzlink::Message _mission_definition_message)
+    {
+        mission_definition_message = _mission_definition_message;
+        main_item->setText(1, _mission_definition_message.getDefinition().getName());
+        float _dval;
+        _mission_definition_message.getField("duration", _dval);
+        setDuration(_dval);
+        duration.emplace(_dval);
+
+        for(size_t i = 0; i < _mission_definition_message.getDefinition().getNbFields(); i++)
+        {
+            auto field = _mission_definition_message.getDefinition().getField(i);
+            QString field_name = field.getName();
+            if (field_name == "duration" || field_name == "ac_id" || field_name == "index") continue; // Already displayed
+
+            QTreeWidgetItem* field_item;
+            if (!details.contains(field_name))
+            {
+                field_item = new QTreeWidgetItem(main_item);
+            }
+            else
+            {
+                field_item = details[field_name];
+                
+            }
+            field_item->setText(1, field_name);
+            field_item->setText(2, _mission_definition_message.getFieldAsStr(i));
+            field_item->setToolTip(2, _mission_definition_message.getFieldAsStr(i));
+            details[field_name] = field_item;
+        }
+    }
+
+    void setActive(bool _active)
+    {   
+        active = _active;
+        main_item->setHidden(!_active);
+        main_item->setDisabled(!_active);
+    }
+};
+
+class MissionModel : public QTreeWidget
+{
+    Q_OBJECT
+public:
+    explicit MissionModel(QString ac_id, QWidget *parent = nullptr);
+
+signals:
+
+public slots:
+
+private:
+    QString ac_id;
+    uint8_t active_missions_count = 0;
+
+    QString labels_stylesheet;
+
+    QSet<uint8_t> active_missions = QSet<uint8_t>(); // Set of active mission ids
+    QMap<uint8_t,MissionInfo*> missions = QMap<uint8_t,MissionInfo*>(); // Map from mission id to mission info
+
+    void updateActiveMissions(float remaining_time, const QList<uint8_t> &missions);
+    
+};
+
+#endif // MISSION_MODEL_H

--- a/src/widgets/mission_model.h
+++ b/src/widgets/mission_model.h
@@ -23,6 +23,31 @@ static const std::array<QString, 9> MISSION_MSG_NAMES = {
         "MISSION_CUSTOM"
     };
 
+class MissionInfo;
+
+class MissionModel : public QTreeWidget
+{
+    Q_OBJECT
+public:
+    QString ac_id;
+    explicit MissionModel(QString ac_id, QWidget *parent = nullptr);
+
+signals:
+
+public slots:
+
+private:
+    uint8_t active_missions_count = 0;
+
+    QString labels_stylesheet;
+
+    QSet<uint8_t> active_missions = QSet<uint8_t>(); // Set of active mission ids
+    QMap<uint8_t,MissionInfo*> missions = QMap<uint8_t,MissionInfo*>(); // Map from mission id to mission info
+
+    void updateActiveMissions(float remaining_time, const QList<uint8_t> &missions);
+    
+};
+
 class MissionInfo
 {
 private:
@@ -33,25 +58,14 @@ private:
 
     QTreeWidgetItem* main_item;
     QMap<QString, QTreeWidgetItem*> details = QMap<QString, QTreeWidgetItem*>();
+
+    void setupGotoButton(MissionModel* parent);
+
 public:
     // ----- Constructors -----
     MissionInfo() = delete;
-    MissionInfo(QTreeWidget* parent, uint8_t _id, uint8_t _rank) : id(_id), rank(_rank)
-    {
-        main_item = new QTreeWidgetItem(parent);
-        main_item->setText(0, QString::number(rank));
-        main_item->setText(1, "UNKNOWN");
-        main_item->setText(2, QString::number(id));
-        main_item->setText(3, "--");
-    }
-    MissionInfo(QTreeWidget* parent, uint8_t _id, uint8_t _rank, pprzlink::Message _mission_definition_message) :
-        id(_id), rank(_rank), mission_definition_message(_mission_definition_message)
-    {
-        main_item = new QTreeWidgetItem(parent);
-        main_item->setText(0, QString::number(rank));
-        main_item->setText(2, QString::number(id));
-        setMissionDefinitionMessage(_mission_definition_message);
-    }
+    MissionInfo(MissionModel* parent, uint8_t _id, uint8_t _rank);
+    MissionInfo(MissionModel* parent, uint8_t _id, uint8_t _rank, pprzlink::Message _mission_definition_message);
 
     // ----- Getters -----
     uint8_t getId() const { return id; }
@@ -129,27 +143,54 @@ public:
     }
 };
 
-class MissionModel : public QTreeWidget
+
+class MissionWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit MissionModel(QString ac_id, QWidget *parent = nullptr);
+    QString ac_id;
+    explicit MissionWidget(QString _ac_id, QWidget *parent = nullptr)
+    : QWidget(parent), ac_id(_ac_id)
+    {
+        layout = new QVBoxLayout(this);
+        layout->addWidget(buildNextMissionButton());
+        layout->addWidget(buildEndMissionButton());
 
-signals:
-
-public slots:
+        auto mission_model = new MissionModel(ac_id, this);
+        layout->addWidget(mission_model);
+        
+    }
 
 private:
-    QString ac_id;
-    uint8_t active_missions_count = 0;
+    QVBoxLayout *layout;
 
-    QString labels_stylesheet;
+    QPushButton * buildEndMissionButton()
+    {
+        auto button = new QPushButton("End Mission", this);
+        button->setIcon(this->style()->standardIcon(QStyle::SP_DialogCloseButton));
+        button->setToolTip("End all missions");
+        connect(button, &QPushButton::clicked, this, [=]()
+        {
+            pprzlink::Message msg(PprzDispatcher::get()->getDict()->getDefinition("END_MISSION"));
+            msg.addField("ac_id", ac_id.toUInt());
+            PprzDispatcher::get()->sendMessage(msg);
+        });
+        return button;
+    }
 
-    QSet<uint8_t> active_missions = QSet<uint8_t>(); // Set of active mission ids
-    QMap<uint8_t,MissionInfo*> missions = QMap<uint8_t,MissionInfo*>(); // Map from mission id to mission info
-
-    void updateActiveMissions(float remaining_time, const QList<uint8_t> &missions);
-    
+    QPushButton * buildNextMissionButton()
+    {
+        auto button = new QPushButton("Next Mission", this);
+        button->setIcon(this->style()->standardIcon(QStyle::SP_ArrowRight));
+        button->setToolTip("Skip to next mission");
+        connect(button, &QPushButton::clicked, this, [=]()
+        {
+            pprzlink::Message msg(PprzDispatcher::get()->getDict()->getDefinition("NEXT_MISSION"));
+            msg.addField("ac_id", ac_id.toUInt());
+            PprzDispatcher::get()->sendMessage(msg);
+        });
+        return button;
+    }
 };
 
 #endif // MISSION_MODEL_H

--- a/src/widgets/mission_model.h
+++ b/src/widgets/mission_model.h
@@ -45,6 +45,7 @@ private:
     QMap<uint8_t,MissionInfo*> missions = QMap<uint8_t,MissionInfo*>(); // Map from mission id to mission info
 
     void updateActiveMissions(float remaining_time, const QList<uint8_t> &missions);
+    void handleMissionUpdate(QString sender, const pprzlink::Message &msg);
     
 };
 
@@ -73,6 +74,7 @@ public:
     optional<float> getDuration() const { return duration; }
     optional<pprzlink::Message> getMissionDefinitionMessage() const { return mission_definition_message; }
     bool isActive() const { return active; }
+    QString getType() const { return main_item->text(1);}
 
     QTreeWidgetItem* getMainItem() const
     {
@@ -133,6 +135,33 @@ public:
             field_item->setToolTip(2, _mission_definition_message.getFieldAsStr(i));
             details[field_name] = field_item;
         }
+    }
+
+    void setFieldValueTxt(QString field_name, QString txtValue)
+    {
+        if (field_name == "ac_id")
+        {
+            setId(field_name.toUInt());
+        }
+        else if (field_name == "duration")
+        {
+            setDuration(field_name.toFloat());
+        }
+        else if (field_name == "index")
+        {
+            setId(field_name.toUInt());
+        }
+        else if (details.contains(field_name))
+        {
+            QTreeWidgetItem* field_item = details[field_name];
+            field_item->setText(2,txtValue);
+        }
+        else
+        {
+            throw pprzlink::no_such_field("No field " + field_name + " in message " + getType());
+        }
+        
+        
     }
 
     void setActive(bool _active)


### PR DESCRIPTION
The widget binds to two types of messages:

- "MISSION_STATUS" from `telemetry`: yields the current missions of the aircraft, in which order they are stored. This updates the widget often
- "MISSION_(.*)" from `datalink`: messages usually coming from ground giving instructions to the aircraft. These messages contain the detailed information; they should be caught before the "MISSION_STATUS" one in order to show the details

Lots of changes in CMakeLists.txt because files are now sorted by name :)

TODOs:

- [x] Handle "MISSION_UPDATE" messages: Done, but only for MISSION_CUSTOM type (as behavior is not implemented in Paparazzi right now for other mission types)
- [x] Allow sending basic messages such as "GOTO_MISSION", "NEXT_MISSION" and "END_MISSION" from the UI 
