### PR TITLE
Warning fixing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GNUInstallDirs)
 
 set(CXX_EXTRA_FLAGS "-Wall -Wextra -fno-sized-deallocation")
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${CXX_EXTRA_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${CXX_EXTRA_FLAGS} -Werror")
 

--- a/docs/source/developer_guide/widgets.rst
+++ b/docs/source/developer_guide/widgets.rst
@@ -79,7 +79,7 @@ Finally, you can bind a callback to any message with the PprzDispatcher's ``bind
 .. code-block:: cpp
 
     pprzApp()->toolbox()->pprzDispatcher()->bind("INTRUDER", this,
-            [=](QString sender, pprzlink::Message msg) {
+            [=,this](QString sender, pprzlink::Message msg) {
                 onIntruder(sender, msg);
             });
 

--- a/src/app_settings.cpp
+++ b/src/app_settings.cpp
@@ -151,7 +151,7 @@ SettingsEditor::SettingsEditor(bool standalone, QWidget* parent): QDialog(parent
     auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     lay->addWidget(buttonBox);
 
-    connect(buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, [=](){
+    connect(buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, [this](){
         for(auto &cb:callbacks) {
             cb();
         }
@@ -165,7 +165,7 @@ SettingsEditor::SettingsEditor(bool standalone, QWidget* parent): QDialog(parent
         }
     });
 
-    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, [=](){
+    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, [=,this](){
         reject();
         if(standalone) {
             qDebug() << "Restarting application...";
@@ -190,7 +190,7 @@ std::function<void()> SettingsEditor::addSetting(QString name, QString key, QWid
         auto edit = new QLineEdit(settings.value(key).toString(), w);
         gl->addWidget(edit, r, 1);
 
-        auto cb = [=]() {
+        auto cb = [=,this]() {
           auto settings = getAppSettings();
           settings.setValue(key, edit->text());
         };
@@ -200,7 +200,7 @@ std::function<void()> SettingsEditor::addSetting(QString name, QString key, QWid
         auto edit = new QLineEdit(settings.value(key).toString(), w);
         gl->addWidget(edit, r, 1);
 
-        auto cb = [=]() {
+        auto cb = [=,this]() {
           auto settings = getAppSettings();
           settings.setValue(key, edit->text().toInt());
         };
@@ -210,7 +210,7 @@ std::function<void()> SettingsEditor::addSetting(QString name, QString key, QWid
         auto edit = new QLineEdit(settings.value(key).toString(), w);
         gl->addWidget(edit, r, 1);
 
-        auto cb = [=]() {
+        auto cb = [=,this]() {
           auto settings = getAppSettings();
           settings.setValue(key, edit->text().toDouble());
         };
@@ -223,7 +223,7 @@ std::function<void()> SettingsEditor::addSetting(QString name, QString key, QWid
         QToolButton* but = new QToolButton(w);
         but->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
         gl->addWidget(but, r, 2);
-        connect(but, &QToolButton::clicked, this, [=]() {
+        connect(but, &QToolButton::clicked, this, [=,this]() {
             auto dir = QFileDialog::getExistingDirectory(w, name, edit->text());
             qDebug() << dir;
             if(dir != "") {
@@ -231,7 +231,7 @@ std::function<void()> SettingsEditor::addSetting(QString name, QString key, QWid
             }
         });
 
-        auto cb = [=]() {
+        auto cb = [=,this]() {
           auto settings = getAppSettings();
           settings.setValue(key, edit->text());
         };
@@ -244,7 +244,7 @@ std::function<void()> SettingsEditor::addSetting(QString name, QString key, QWid
         QToolButton* but = new QToolButton(w);
         but->setIcon(style()->standardIcon(QStyle::SP_DirOpenIcon));
         gl->addWidget(but, r, 2);
-        connect(but, &QToolButton::clicked, this, [=]() {
+        connect(but, &QToolButton::clicked, this, [=,this]() {
             QFileInfo fi(edit->text());
             auto dir = QFileDialog::getOpenFileName(w, name, fi.absoluteDir().path());
             qDebug() << dir;
@@ -253,7 +253,7 @@ std::function<void()> SettingsEditor::addSetting(QString name, QString key, QWid
             }
         });
 
-        auto cb = [=]() {
+        auto cb = [=,this]() {
           auto settings = getAppSettings();
           settings.setValue(key, edit->text());
         };
@@ -266,7 +266,7 @@ std::function<void()> SettingsEditor::addSetting(QString name, QString key, QWid
         combo->setCurrentText(current);
         gl->addWidget(combo, r, 1);
 
-        auto cb = [=]() {
+        auto cb = [=,this]() {
             auto settings = getAppSettings();
             settings.setValue(key, combo->currentText());
         };

--- a/src/common/aircraft_status.cpp
+++ b/src/common/aircraft_status.cpp
@@ -9,7 +9,7 @@ AircraftStatus::AircraftStatus(QString ac_id, QObject *parent) : QObject(parent)
     watcher = new AircraftWatcher(ac_id, this);
 
     //listen for NAVIGATION_REF to update origin waypoint of fixedwings
-    PprzDispatcher::get()->bind("NAVIGATION_REF", this, [=](QString sender, pprzlink::Message msg) {
+    PprzDispatcher::get()->bind("NAVIGATION_REF", this, [=,this](QString sender, pprzlink::Message msg) {
         if(sender == ac_id) {
             int32_t utm_east, utm_north;
             uint8_t utm_zone;
@@ -27,7 +27,7 @@ AircraftStatus::AircraftStatus(QString ac_id, QObject *parent) : QObject(parent)
     });
 
     //listen for INS_REF to update origin waypoint of rotorcrafts
-    PprzDispatcher::get()->bind("INS_REF", this, [=](QString sender, pprzlink::Message msg) {
+    PprzDispatcher::get()->bind("INS_REF", this, [=,this](QString sender, pprzlink::Message msg) {
         if(sender == ac_id) {
 
             int32_t lat0, lon0, alt0;

--- a/src/common/setting.cpp
+++ b/src/common/setting.cpp
@@ -80,7 +80,7 @@ Setting::Setting(QDomElement setel, uint8_t& setting_no, QObject* parent) : QObj
 }
 
 float Setting::getAltUnitCoef(QString altUnit) {
-    auto coef_alt = [=](QString alt){
+    auto coef_alt = [=,this](QString alt){
         auto coef = Units::get()->getCoef(unit, alt);
         if(coef.has_value()) {
             return coef.value();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,6 @@ int main(int argc, char *argv[])
         parser.addVersionOption();
         parser.addOption({{"c", "configure"}, "Configure app settings."});
         parser.addOption({{"s", "silent"}, "Silent mode."});
-        parser.addOption({{"v", "verbose"}, "Verbose"});
         parser.addOption({{"f", "fpedit"}, "edit flight plan", "file"});
         parser.addOption({{"b", "bus"}, "Ivy bus", "bus"});
 #if defined(SPEECH_ENABLED)

--- a/src/pprzmain.cpp
+++ b/src/pprzmain.cpp
@@ -64,21 +64,21 @@ void PprzMain::populate_menu() {
     auto file_menu = menu_bar->addMenu("&File");
 
     auto user_dir = file_menu->addAction("Open user directory");
-    connect(user_dir, &QAction::triggered, [=](){
+    connect(user_dir, &QAction::triggered, [=,this](){
         auto settings = getAppSettings();
         QString path = QDir::toNativeSeparators(appConfig()->value("USER_DATA_PATH").toString());
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
     });
 
     auto app_dir = file_menu->addAction("Open app directory");
-    connect(app_dir, &QAction::triggered, [=](){
+    connect(app_dir, &QAction::triggered, [=,this](){
         auto settings = getAppSettings();
         QString path = QDir::toNativeSeparators(appConfig()->value("APP_DATA_PATH").toString());
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
     });
 
     auto edit_settings = file_menu->addAction("Edit Settings");
-    connect(edit_settings, &QAction::triggered, [=](){
+    connect(edit_settings, &QAction::triggered, [=,this](){
         auto se = new SettingsEditor();
         se->open();
     });
@@ -96,7 +96,7 @@ void PprzMain::populate_menu() {
     map_track_ac->setChecked(false);
 
     auto open_flight_plan = file_menu->addAction("Open FlightPlans");
-    connect(open_flight_plan, &QAction::triggered, [=](){
+    connect(open_flight_plan, &QAction::triggered, [=,this](){
         auto settings = getAppSettings();
         auto pprz_home = appConfig()->value("PAPARAZZI_HOME").toString();
         auto files = QFileDialog::getOpenFileNames(this, "open fp", pprz_home + "/conf/flight_plans", "*.xml");
@@ -157,7 +157,7 @@ void PprzMain::populate_menu() {
             "<li><a %1 href=\"https://libzip.org/\">libzip</a></li>"
             "</ul>").arg(QCoreApplication::applicationVersion());
 
-    connect(about, &QAction::triggered, [=]() {
+    connect(about, &QAction::triggered, [=,this]() {
         QMessageBox::about(this,"About PprzGCS", about_txt);
 
     });

--- a/src/tools/AircraftManager.cpp
+++ b/src/tools/AircraftManager.cpp
@@ -181,7 +181,7 @@ void ConfigData::setData(QDomDocument* doc, QString uri) {
         }
     } else if(uri.left(sepi) == "http") {
         auto netacc = new QNetworkAccessManager(this);
-        connect(netacc, &QNetworkAccessManager::finished, this, [=](QNetworkReply* reply) {
+        connect(netacc, &QNetworkAccessManager::finished, this, [=,this](QNetworkReply* reply) {
             auto data = reply->readAll();
             if(reply->error() == QNetworkReply::NetworkError::NoError) {
                 doc->setContent(data);

--- a/src/tools/dispatcher_ui.cpp
+++ b/src/tools/dispatcher_ui.cpp
@@ -3,7 +3,7 @@
 DispatcherUi::DispatcherUi(PprzApplication* app, PprzToolbox* toolbox) : PprzTool(app, toolbox),
     selected_ac_id("")
 {
-    connect(this, &DispatcherUi::ac_selected, [=](QString ac_id){
+    connect(this, &DispatcherUi::ac_selected, [=,this](QString ac_id){
         selected_ac_id = ac_id;
     });
 

--- a/src/tools/grpcconnector.cpp
+++ b/src/tools/grpcconnector.cpp
@@ -44,7 +44,7 @@ GRPCConnector::GRPCConnector(PprzApplication* app, PprzToolbox* toolbox) : PprzT
 void GRPCConnector::setToolbox(PprzToolbox* toolbox) {
     PprzTool::setToolbox(toolbox);
 
-    auto th = QThread::create([=] {
+    auto th = QThread::create([=,this] {
         this->runServer();
     });
     th->start();

--- a/src/tools/pprz_dispatcher.cpp
+++ b/src/tools/pprz_dispatcher.cpp
@@ -32,7 +32,7 @@ void PprzDispatcher::setToolbox(PprzToolbox* toolbox) {
     dict = new pprzlink::MessageDictionary(messages);
     link = new pprzlink::IvyQtLink(*dict, ivy_name, this);
 
-    connect(link, &pprzlink::IvyQtLink::serverConnected, this, [=]() {
+    connect(link, &pprzlink::IvyQtLink::serverConnected, this, [=,this]() {
         started = true;
        requestAircrafts();
     });
@@ -52,7 +52,7 @@ void PprzDispatcher::setToolbox(PprzToolbox* toolbox) {
 
 
     long bid = link->BindMessage(dict->getDefinition("WAYPOINT_MOVED"), nullptr,
-        [=](QString ac_id, pprzlink::Message msg) {
+        [=,this](QString ac_id, pprzlink::Message msg) {
             (void)ac_id;
             QString id;
             uint8_t wp_id = 0;
@@ -65,7 +65,7 @@ void PprzDispatcher::setToolbox(PprzToolbox* toolbox) {
     _bindIds.append(bid);
 
     bid = link->BindMessage(dict->getDefinition("AIRCRAFT_DIE"), nullptr,
-        [=](QString ac_id, pprzlink::Message msg) {
+        [=,this](QString ac_id, pprzlink::Message msg) {
             (void)ac_id;
             QString id;
             msg.getField("ac_id", id);
@@ -90,7 +90,7 @@ void PprzDispatcher::setToolbox(PprzToolbox* toolbox) {
 
 
     connect(DispatcherUi::get(), &DispatcherUi::move_waypoint_ui, this,
-        [=](Waypoint* wp, QString ac_id) {
+        [=,this](Waypoint* wp, QString ac_id) {
             //Do not send the message if this is a "flight plan only" AC.
             if(AircraftManager::get()->getAircraft(ac_id)->isReal()) {
                 pprzlink::Message msg(dict->getDefinition("MOVE_WAYPOINT"));
@@ -107,7 +107,7 @@ void PprzDispatcher::setToolbox(PprzToolbox* toolbox) {
         });
 
     bid = link->BindMessage(dict->getDefinition("NEW_AIRCRAFT"), nullptr,
-        [=](QString ac_id, pprzlink::Message msg) {
+        [=,this](QString ac_id, pprzlink::Message msg) {
             (void)ac_id;
             QString id;
             msg.getField("ac_id", id);
@@ -132,7 +132,7 @@ void PprzDispatcher::unbindAll() {
 
 void PprzDispatcher::bindDeftoSignal(QString const &name, sig_ptr_t sig) {
     long bid = link->BindMessage(dict->getDefinition(name), nullptr,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             if(sender == "ground") {
                 time_msg_server = QDateTime::currentMSecsSinceEpoch();
             }
@@ -156,7 +156,7 @@ void PprzDispatcher::requestConfig(QString ac_id) {
     pprzlink::Message reqConfig(dict->getDefinition("CONFIG_REQ"));
     reqConfig.addField("ac_id", ac_id);
     reqConfig.setSenderId(pprzlink_id);
-    link->sendRequest(reqConfig, [=](QString ai, pprzlink::Message msg) {
+    link->sendRequest(reqConfig, [=,this](QString ai, pprzlink::Message msg) {
         (void)ai;
         AircraftManager::get()->newAircraftConfig(msg);
     });
@@ -175,7 +175,7 @@ void PprzDispatcher::requestAircrafts() {
     pprzlink::Message msg(def_ar);
     msg.setSenderId(pprzlink_id);
 
-    link->sendRequest(msg, [=](QString sender, pprzlink::Message msg) {
+    link->sendRequest(msg, [=,this](QString sender, pprzlink::Message msg) {
         (void)sender;
         QString ac_list;
         msg.getField("ac_list", ac_list);

--- a/src/tools/speaker.cpp
+++ b/src/tools/speaker.cpp
@@ -105,7 +105,7 @@ void Speaker::bindMessage(struct Message msg) {
     auto msg_class = def[0];
 
     auto bid = PprzDispatcher::get()->bind(def[1], this,
-        [=](QString sender, pprzlink::Message pprz_msg){
+        [=,this](QString sender, pprzlink::Message pprz_msg){
 
             QString ac_id;
             if(msg_class == "ground") {

--- a/src/tools/srtm_manager.cpp
+++ b/src/tools/srtm_manager.cpp
@@ -122,7 +122,7 @@ void SRTMManager::load_tiles(QList<QString> names, bool local_only) {
     if(tiles_dl.size() > 0 && !local_only) {
         auto dialog = new SRTMDialog(tiles_dl);
 
-        connect(dialog, &SRTMDialog::tilesConfirmed, this, [=](QList<QString> tiles_confirmed) {
+        connect(dialog, &SRTMDialog::tilesConfirmed, this, [=,this](QList<QString> tiles_confirmed) {
             for(auto &name: tiles_confirmed) {
                 load_tile(name, true);
             }
@@ -236,7 +236,7 @@ SRTMDialog::SRTMDialog(QList<QString> tiles_names, QWidget *parent) : QDialog(pa
         chk_tiles.append(ck);
     }
 
-    connect(select_all, &QCheckBox::toggled, this, [=](bool checked) {
+    connect(select_all, &QCheckBox::toggled, this, [=,this](bool checked) {
         for(auto &ck: chk_tiles) {
             ck->setChecked(checked);
         }
@@ -246,7 +246,7 @@ SRTMDialog::SRTMDialog(QList<QString> tiles_names, QWidget *parent) : QDialog(pa
     auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     lay->addWidget(buttonBox);
 
-    connect(buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, [=]() {
+    connect(buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, [=,this]() {
         QList<QString> tiles_ok;
         for(auto ck: chk_tiles) {
             if(ck->isChecked()) {
@@ -257,7 +257,7 @@ SRTMDialog::SRTMDialog(QList<QString> tiles_names, QWidget *parent) : QDialog(pa
         accept();
     });
 
-    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, [=](){
+    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, [=,this](){
         reject();
     });
 }

--- a/src/widgets/ac_selector.cpp
+++ b/src/widgets/ac_selector.cpp
@@ -11,7 +11,7 @@ ACSelector::ACSelector(QWidget *parent) : QWidget(parent)
     connect(DispatcherUi::get(), &DispatcherUi::new_ac_config, this, &ACSelector::handleNewAC);
     connect(DispatcherUi::get(), &DispatcherUi::ac_deleted, this, &ACSelector::removeAC);
     connect(DispatcherUi::get(), &DispatcherUi::ac_selected, this,
-            [=](QString ac_id) {
+            [this](QString ac_id) {
                 current_ac_id = ac_id;
                 repaint();
             });

--- a/src/widgets/basics/chatbubble.cpp
+++ b/src/widgets/basics/chatbubble.cpp
@@ -45,7 +45,7 @@ ChatBubble::ChatBubble(QString source, QString dest, QString msg, bool sent, QWi
     }
 
     // delay set max width to wait for the widget to be shown.
-    QTimer::singleShot(20, this, [=](){
+    QTimer::singleShot(20, this, [=,this](){
             auto width = size().width() * 0.95;
             ui->frame->setMaximumWidth(width);
     });

--- a/src/widgets/basics/graphwidget.cpp
+++ b/src/widgets/basics/graphwidget.cpp
@@ -81,8 +81,8 @@ void GraphWidget::paintEvent(QPaintEvent *e) {
 
 
 
-    auto y_of_val = [=](double val){return graph_rect.bottom() - ((val - min)*graph_rect.height())/(max-min);};
-    val_of_y = [=](int y){return ((graph_rect.bottom()-y)*(max-min)/graph_rect.height()) + min;};
+    auto y_of_val = [=,this](double val){return graph_rect.bottom() - ((val - min)*graph_rect.height())/(max-min);};
+    val_of_y = [=,this](int y){return ((graph_rect.bottom()-y)*(max-min)/graph_rect.height()) + min;};
 
     int max_w = 0;
     QList<int> ylines;
@@ -123,8 +123,8 @@ void GraphWidget::paintEvent(QPaintEvent *e) {
     }
 
     auto now = QTime::currentTime();
-    auto x_of_t = [=](int dt){return graph_rect.right() - (graph_rect.width()*dt)/history;};
-    auto dt_of_x = [=](int x){return ((graph_rect.right() - x) * history) / graph_rect.width();};
+    auto x_of_t = [=,this](int dt){return graph_rect.right() - (graph_rect.width()*dt)/history;};
+    auto dt_of_x = [=,this](int x){return ((graph_rect.right() - x) * history) / graph_rect.width();};
 
     // draw time scale
     p.setBrush(Qt::NoBrush);
@@ -218,7 +218,7 @@ void GraphWidget::wheelEvent(QWheelEvent *event) {
 }
 
 void GraphWidget::mousePressEvent(QMouseEvent *event) {
-    val_last_move = val_of_y(event->y());
+    val_last_move = val_of_y(event->position().y());
     moving = true;
 }
 
@@ -242,7 +242,7 @@ void GraphWidget::mouseMoveEvent(QMouseEvent *event) {
     if(moving) {
         params.autoscale = false;
         emit autoscaleChanged(params.autoscale);
-        double val_current = val_of_y(event->y());
+        double val_current = val_of_y(event->position().y());
         params.max += (val_last_move - val_current);
         params.min += (val_last_move - val_current);
     }

--- a/src/widgets/chat.cpp
+++ b/src/widgets/chat.cpp
@@ -22,7 +22,7 @@ Chat::Chat(QWidget *parent) :
     connect(DispatcherUi::get(), &DispatcherUi::new_ac_config, this,  &Chat::onNewAircraft);
     connect(DispatcherUi::get(), &DispatcherUi::ac_deleted, this, &Chat::onAcDeleted);
 
-    PprzDispatcher::get()->bind("INFO_MSG", this, [=](QString sender, pprzlink::Message msg) {
+    PprzDispatcher::get()->bind("INFO_MSG", this, [=,this](QString sender, pprzlink::Message msg) {
         QByteArray ar;
         msg.getField("msg", ar);
         auto txt = QString(ar);
@@ -30,7 +30,7 @@ Chat::Chat(QWidget *parent) :
     });
 
     try {
-        PprzDispatcher::get()->bind("INFO_MSG_GROUND", this, [=](QString sender, pprzlink::Message msg) {
+        PprzDispatcher::get()->bind("INFO_MSG_GROUND", this, [=,this](QString sender, pprzlink::Message msg) {
             (void) sender;
             QString txt;
             QString source;
@@ -133,7 +133,7 @@ void Chat::addMessage(QString txt, QString source, QString dst, bool sent) {
     ui->scroll_widget->installEventFilter(cb);
 
     // delay scroll to bottom to wait for the x=widget to be repainted.
-    QTimer::singleShot(20, this, [=](){
+    QTimer::singleShot(20, this, [=,this](){
         ui->scrollArea->verticalScrollBar()->setSliderPosition(ui->scrollArea->verticalScrollBar()->maximum());
     });
 

--- a/src/widgets/checklist.cpp
+++ b/src/widgets/checklist.cpp
@@ -42,7 +42,7 @@ Checklist::Checklist(QString ac_id, QWidget *parent) :
             ui->verticalLayout->addWidget(widget_item);
 
             connect(widget_item, &QCheckBox::toggled, this, 
-            [=](bool state) {
+            [=,this](bool state) {
                 item->value = (state)? "true":"false";
                 sendMessage(ac_id, item);
 
@@ -60,7 +60,7 @@ Checklist::Checklist(QString ac_id, QWidget *parent) :
             ui->verticalLayout->addLayout(widget_item);
 
             connect(widget_input, &QLineEdit::editingFinished, this, 
-            [=]() {
+            [=,this]() {
                 item->value = widget_input->text();
                 sendMessage(ac_id, item);
 

--- a/src/widgets/commands.cpp
+++ b/src/widgets/commands.cpp
@@ -86,7 +86,7 @@ void Commands::addFlightPlanButtons(QGridLayout* fp_buttons_layout) {
             if(b != nullptr) {
                 fp_buttons_layout->addWidget(b, row, col);
                   connect(b, &QPushButton::clicked, this,
-                    [=]() {
+                    [=,this]() {
                         pprzlink::Message msg(PprzDispatcher::get()->getDict()->getDefinition("JUMP_TO_BLOCK"));
                         msg.addField("ac_id", ac_id);
                         msg.addField("block_id", block->getNo());
@@ -126,7 +126,7 @@ void Commands::addSettingsButtons(QGridLayout* settings_buttons_layout) {
             if(b != nullptr) {
                 settings_buttons_layout->addWidget(b, row, col);
                   connect(b, &QPushButton::clicked, this,
-                    [=]() {
+                    [=,this]() {
                         AircraftManager::get()->getAircraft(ac_id)->setSetting(sb->setting_no, sb->value);
                 });
             }
@@ -146,17 +146,17 @@ void Commands::addSpecialCommands(QGridLayout* glay) {
 
     for(auto set:settings) {
         if(set->getName() == "autopilot.launch") {
-            addCommandButton(glay, "launch.png", 0, 1, [=]() mutable {
+            addCommandButton(glay, "launch.png", 0, 1, [=,this]() mutable {
                 ac->setSetting(set, 1);
             }, "Launch");
         }
 
         if(set->getName() == "autopilot.kill_throttle") {
-            addCommandButton(glay, "kill.png", 0, 2, [=]() mutable {
+            addCommandButton(glay, "kill.png", 0, 2, [=,this]() mutable {
                 ac->setSetting(set, 1);
             }, "Kill throttle");
 
-            addCommandButton(glay, "resurrect.png", 0, 3, [=]() mutable {
+            addCommandButton(glay, "resurrect.png", 0, 3, [=,this]() mutable {
                 ac->setSetting(set, 0);
             }, "Resurrect throttle");
         }
@@ -166,29 +166,29 @@ void Commands::addSpecialCommands(QGridLayout* glay) {
           float altShiftMinus = ac->getAirframe()->getAltShiftMinus();
           float altShiftPlusPlus = ac->getAirframe()->getAltShiftPlusPlus();
 
-          addCommandButton(glay, "up.png", 1, 1, [=]() mutable {
+          addCommandButton(glay, "up.png", 1, 1, [=,this]() mutable {
                 ac->setSetting(set, target_alt + altShiftPlus);
             }, QString("+%1").arg(altShiftPlus, 0, 'f', 1));
 
-            addCommandButton(glay, "down.png", 1, 2, [=]() mutable {
+            addCommandButton(glay, "down.png", 1, 2, [=,this]() mutable {
                 ac->setSetting(set, target_alt + altShiftMinus);
             }, QString("%1").arg(altShiftMinus, 0, 'f', 1));
 
-            addCommandButton(glay, "upup.png", 1, 3, [=]() mutable {
+            addCommandButton(glay, "upup.png", 1, 3, [=,this]() mutable {
                 ac->setSetting(set, target_alt + altShiftPlusPlus);
             }, QString("+%1").arg(altShiftPlusPlus, 0, 'f', 1));
         }
 
         if(set->getName() == "inc. shift") {
-            addCommandButton(glay, "left.png", 2, 1, [=]() mutable {
+            addCommandButton(glay, "left.png", 2, 1, [=,this]() mutable {
                 ac->setSetting(set, -5);
             }, "-5");
 
-            addCommandButton(glay, "recenter.png", 2, 2, [=]() mutable {
+            addCommandButton(glay, "recenter.png", 2, 2, [=,this]() mutable {
                 ac->setSetting(set, 0);
             }, "0");
 
-            addCommandButton(glay, "right.png", 2, 3, [=]() mutable {
+            addCommandButton(glay, "right.png", 2, 3, [=,this]() mutable {
                 qDebug() << "current value: " << set->getUserValue() << "  (+5)";
                 ac->setSetting(set, 5);
             }, "+5");

--- a/src/widgets/flightplan_viewerv2.cpp
+++ b/src/widgets/flightplan_viewerv2.cpp
@@ -45,7 +45,7 @@ QWidget* FlightPlanViewerV2::make_blocks_tab() {
         auto go_button = new QToolButton(widget);
         go_button->setText(QString::fromUtf8("\xE2\x86\x92"));
         connect(go_button, &QPushButton::clicked, this,
-            [=]() {
+            [=,this]() {
                 pprzlink::Message msg(PprzDispatcher::get()->getDict()->getDefinition("JUMP_TO_BLOCK"));
                 msg.addField("ac_id", ac_id);
                 msg.addField("block_id", block->getNo());
@@ -91,7 +91,7 @@ void FlightPlanViewerV2::handleNavStatus() {
         QTimer* timer = new QTimer();
         timer->moveToThread(qApp->thread());
         timer->setSingleShot(true);
-        QObject::connect(timer, &QTimer::timeout, this, [=]()
+        QObject::connect(timer, &QTimer::timeout, this, [=,this]()
         {
             // main thread
             updateNavStatus(cur_block, cur_stage);

--- a/src/widgets/flightplaneditor.cpp
+++ b/src/widgets/flightplaneditor.cpp
@@ -46,7 +46,7 @@ FlightPlanEditor::FlightPlanEditor(QString ac_id, QWidget *parent) : QWidget(par
     }
 
     if(!readOnly) {
-        connect(ui->validate_button, &QPushButton::clicked, this, [=]() {
+        connect(ui->validate_button, &QPushButton::clicked, this, [=,this]() {
             bool result = validate();
             if(result) {
                 QMessageBox::information(this, "DTD Validation", "XML is valid!");
@@ -55,7 +55,7 @@ FlightPlanEditor::FlightPlanEditor(QString ac_id, QWidget *parent) : QWidget(par
             }
         });
 
-        connect(ui->save_button, &QPushButton::clicked, this, [=]() {
+        connect(ui->save_button, &QPushButton::clicked, this, [=,this]() {
             auto data = output();
             auto out_path = QUrl(config->getFlightPlanUri()).toLocalFile();
             out_path = QFileDialog::getSaveFileName(this, "save btu", out_path);
@@ -70,15 +70,15 @@ FlightPlanEditor::FlightPlanEditor(QString ac_id, QWidget *parent) : QWidget(par
             }
         });
 
-        connect(ui->up_button, &QPushButton::clicked, this, [=]() {
+        connect(ui->up_button, &QPushButton::clicked, this, [=,this]() {
             onArrowClicked(true);
         });
 
-        connect(ui->down_button, &QPushButton::clicked, this, [=]() {
+        connect(ui->down_button, &QPushButton::clicked, this, [=,this]() {
             onArrowClicked(false);
         });
 
-        connect(ui->attributes, &QTreeWidget::itemDoubleClicked, this, [=](QTreeWidgetItem * item, int column) {
+        connect(ui->attributes, &QTreeWidget::itemDoubleClicked, this, [=,this](QTreeWidgetItem * item, int column) {
             if(column == 1) {
                 ui->attributes->editItem(item, column);
             }
@@ -95,7 +95,7 @@ FlightPlanEditor::FlightPlanEditor(QString ac_id, QWidget *parent) : QWidget(par
         ui->up_button->hide();
         ui->down_button->hide();
 
-        connect(ui->tree, &QTreeWidget::itemDoubleClicked, this, [=](QTreeWidgetItem * item, int column) {
+        connect(ui->tree, &QTreeWidget::itemDoubleClicked, this, [=,this](QTreeWidgetItem * item, int column) {
             qDebug() << column << item->text(0) << item->text(1);
         });
 
@@ -368,7 +368,7 @@ void FlightPlanEditor::openElementsContextMenu(QPoint pos) {
 
     /// Delete action
     auto delete_action = menu->addAction("Delete");
-    connect(delete_action, &QAction::triggered, this, [=]() {
+    connect(delete_action, &QAction::triggered, this, [=,this]() {
         xmlUnlinkNode(node);
         xmlFreeNode(node);
 
@@ -402,7 +402,7 @@ void FlightPlanEditor::openElementsContextMenu(QPoint pos) {
         elements.removeAll("#PCDATA");
         for(auto &name: elements) {
             auto addchild_action = childMenu->addAction(name);
-            connect(addchild_action, &QAction::triggered, this, [=]() {
+            connect(addchild_action, &QAction::triggered, this, [=,this]() {
                 item->setExpanded(true);
                 xmlNodePtr new_node = xmlNewNode(nullptr, BAD_CAST name.toStdString().c_str());
                 for(auto att: attributeDefs(new_node->name)) {
@@ -433,7 +433,7 @@ void FlightPlanEditor::openElementsContextMenu(QPoint pos) {
 
     ///Copy after action
     auto copy_action = menu->addAction("Copy after");
-    connect(copy_action, &QAction::triggered, this, [=]() {
+    connect(copy_action, &QAction::triggered, this, [=,this]() {
         auto copy = xmlCopyNode(node, 1);
         xml_add_next_sibling(node, copy);
         if(QString((char*)copy->name) == "waypoint") {
@@ -468,7 +468,7 @@ void FlightPlanEditor::openElementsContextMenu(QPoint pos) {
             elements.removeAll("#PCDATA");
             for(auto &name: elements) {
                 auto addafter_action = afterMenu->addAction(name);
-                connect(addafter_action, &QAction::triggered, this, [=]() {
+                connect(addafter_action, &QAction::triggered, this, [=,this]() {
                     xmlNodePtr new_node = xmlNewNode(nullptr, BAD_CAST name.toStdString().c_str());
                     for(auto att: attributeDefs(new_node->name)) {
                         if(att.required) {
@@ -532,7 +532,7 @@ void FlightPlanEditor::openAttributesContextMenu(QPoint pos) {
                 if(att_selected[0]->text(0) == QString((char*)att.name) && !att.required) {
                     /// Delete action
                     auto delete_action = menu->addAction("Delete");
-                    connect(delete_action, &QAction::triggered, this, [=]() {
+                    connect(delete_action, &QAction::triggered, this, [=,this]() {
                         xmlUnsetProp(node, att.name);
                         onItemClicked(node_item, 1);
                     });
@@ -548,7 +548,7 @@ void FlightPlanEditor::openAttributesContextMenu(QPoint pos) {
             if(prop == nullptr) {
                 // Add attribute if not already there
                 auto add_attribute_action = addAttMenu->addAction(QString((char*)att.name));
-                connect(add_attribute_action, &QAction::triggered, this, [=]() {
+                connect(add_attribute_action, &QAction::triggered, this, [=,this]() {
                     xmlSetProp(node, att.name, BAD_CAST "???");
                     onItemClicked(node_item, 1);
                 });
@@ -561,7 +561,7 @@ void FlightPlanEditor::openAttributesContextMenu(QPoint pos) {
         if(QString((char*)node->name) == "waypoint") {
             if(xmlGetProp(node, BAD_CAST "x")) {
                 auto convert_action = menu->addAction("Convert to lat/lon");
-                connect(convert_action, &QAction::triggered, this, [=]() {
+                connect(convert_action, &QAction::triggered, this, [=,this]() {
                     xmlUnsetProp(node, BAD_CAST "x");
                     xmlUnsetProp(node, BAD_CAST "y");
                     auto wp = waypoints[node_item];
@@ -573,7 +573,7 @@ void FlightPlanEditor::openAttributesContextMenu(QPoint pos) {
                 });
             } else if(xmlGetProp(node, BAD_CAST "lat")) {
                 auto convert_action = menu->addAction("Convert to x/y");
-                connect(convert_action, &QAction::triggered, this, [=]() {
+                connect(convert_action, &QAction::triggered, this, [=,this]() {
                     xmlUnsetProp(node, BAD_CAST "lat");
                     xmlUnsetProp(node, BAD_CAST "lon");
                     auto wp = waypoints[node_item];
@@ -777,7 +777,7 @@ void FlightPlanEditor::onNavStatus() {
         return;
     }
 
-    applyRecursive(last, [=](QTreeWidgetItem* item){
+    applyRecursive(last, [=,this](QTreeWidgetItem* item){
         for(int i=0; i<item->columnCount(); ++i) {
             item->setBackground(i, Qt::transparent);
         }
@@ -791,7 +791,7 @@ void FlightPlanEditor::onNavStatus() {
         msg->getField("cur_block", cur_block);
         msg->getField("cur_stage", cur_stage);
 
-        applyRecursive(blocks[cur_block], [=](QTreeWidgetItem* item){
+        applyRecursive(blocks[cur_block], [=,this](QTreeWidgetItem* item){
             QColor color = Qt::darkGreen;
             auto node = nodes[item];
             auto cno = xmlGetProp(node, BAD_CAST "no");

--- a/src/widgets/gps_classic_viewer.cpp
+++ b/src/widgets/gps_classic_viewer.cpp
@@ -6,7 +6,7 @@ GPSClassicViewer::GPSClassicViewer(QString ac_id, QWidget *parent) : QWidget(par
     ac_id(ac_id), reduced(true)
 {
     connect(AircraftManager::get()->getAircraft(ac_id)->getStatus(),
-            &AircraftStatus::engine_status, this, [=]() {
+            &AircraftStatus::engine_status, this, [=,this]() {
         this->update();
     });
 }

--- a/src/widgets/grid_viewer.cpp
+++ b/src/widgets/grid_viewer.cpp
@@ -19,13 +19,13 @@ GridViewer::GridViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(
     grid_layout->addWidget(obstacle_label, 1, 0);
     grid_layout->addWidget(obstacle_button, 1, 1);
 
-    connect(slam_button, &QPushButton::clicked, this, [=]() {
+    connect(slam_button, &QPushButton::clicked, this, [=,this]() {
         bool visible = (slam_button->text() == "ON");
         slam_button->setText(visible ? "OFF" : "ON");
         emit DispatcherUi::get()->slamGridVisibilityChanged(!visible);
     });
 
-    connect(obstacle_button, &QPushButton::clicked, this, [=]() {
+    connect(obstacle_button, &QPushButton::clicked, this, [=,this]() {
         bool visible = (obstacle_button->text() == "ON");
         obstacle_button->setText(visible ? "OFF" : "ON");
         emit DispatcherUi::get()->obstacleVisibilityChanged(!visible);

--- a/src/widgets/gvf_viewer.cpp
+++ b/src/widgets/gvf_viewer.cpp
@@ -62,7 +62,7 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     // GVF Viewer init
     init();
 
-    auto setViewerMode = [=](QString mode) {
+    auto setViewerMode = [=,this](QString mode) {
         if(mode == "DEFAULT") {
             viewer_mode = "DEFAULT";
             gvfV_config[2] = gvfV_default_Vfield_config[0];
@@ -95,7 +95,7 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
 
     // Building signals-slots connections
     connect(DispatcherUi::get(), &DispatcherUi::gvf_defaultFieldSettings, this,
-            [=](QString sender, int area, int xpts, int ypts) {
+            [=,this](QString sender, int area, int xpts, int ypts) {
                 if(sender == ac_id) {
                     gvfV_default_Vfield_config[0] = area;
                     gvfV_default_Vfield_config[1] = xpts;
@@ -105,7 +105,7 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
             });
 
     connect(DispatcherUi::get(), &DispatcherUi::gvf_zlimits, this,
-            [=](QString sender, float minz, float maxz) {
+            [=,this](QString sender, float minz, float maxz) {
                 if(sender == ac_id) {
                     alt_bar->set_zlimits(minz, maxz);
                     alt_bar->repaint();
@@ -114,7 +114,7 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
 
     connect(
         mode_button, &QPushButton::clicked, this,
-        [=]() {
+        [=,this]() {
             if (mode_button->text() == "DEFAULT") {
                 setViewerMode("CUSTOM");
             } else {
@@ -125,7 +125,7 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
 
     connect(
         traj_vis_button, &QPushButton::clicked, this,
-        [=]() {
+        [=,this]() {
             if (traj_vis_button->text() == "ON") {
                 gvfV_config[0] = false;
                 emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
@@ -140,7 +140,7 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
 
     connect(
         field_vis_button, &QPushButton::clicked, this,
-        [=]() {
+        [=,this]() {
             if (field_vis_button->text() == "ON") {
                 gvfV_config[1] = false;
                 emit DispatcherUi::get()->gvf_settingUpdated(ac_id, &gvfV_config);
@@ -154,19 +154,19 @@ GVFViewer::GVFViewer(QString ac_id, QWidget *parent) : QWidget(parent), ac_id(ac
     );
 
     connect(area_spin, qOverload<int>(&QSpinBox::valueChanged), this,
-        [=](int value){
+        [=,this](int value){
             gvfV_config[2] = value;
             setViewerMode("CUSTOM");
         });
 
     connect(xpts_spin, qOverload<int>(&QSpinBox::valueChanged), this,
-        [=](int value){
+        [=,this](int value){
             gvfV_config[3] = value;
             setViewerMode("CUSTOM");
         });
 
     connect(ypts_spin, qOverload<int>(&QSpinBox::valueChanged), this,
-        [=](int value){
+        [=,this](int value){
             gvfV_config[4] = value; 
             setViewerMode("CUSTOM");
         });

--- a/src/widgets/layer_combo.cpp
+++ b/src/widgets/layer_combo.cpp
@@ -156,21 +156,21 @@ void LayerCombo::makeLayerControl(QString name, bool initialState, int z) {
 
     connect(
         layer_control, &MapLayerControl::showLayer, this,
-        [=](bool state) {
+        [=,this](bool state) {
             emit showLayer(name, state, layer_control->zValue(), layer_control->opacity());
         }
     );
 
     connect(
         layer_control, &MapLayerControl::layerOpacityChanged, this,
-        [=](qreal opacity) {
+        [=,this](qreal opacity) {
             emit layerOpacityChanged(name, opacity);
         }
     );
 
     connect(
         layer_control, &MapLayerControl::zValueChanged, this,
-        [=](int z) {
+        [=,this](int z) {
             emit zValueChanged(name, z);
         }
     );

--- a/src/widgets/listcontainer.cpp
+++ b/src/widgets/listcontainer.cpp
@@ -26,7 +26,7 @@ ListContainer::ListContainer(std::function<QWidget*(QString, QWidget*)> construc
 
     // FIXME: small hack to set minimum size of the scrollarea
     QTimer* t = new QTimer(this);
-    connect(t, &QTimer::timeout, this, [=]() {
+    connect(t, &QTimer::timeout, this, [=,this]() {
         this->setMinimumWidth(grid_layout->sizeHint().width());
     });
     t->start(500);
@@ -79,7 +79,7 @@ void ListContainer::handleNewAC(QString ac_id) {
         alt_widget->setWindowFlags(Qt::FramelessWindowHint | Qt::Popup);
 
         connect(action_button, &QToolButton::clicked, this,
-            [=]() {
+            [=,this]() {
                 auto p = action_button->mapToGlobal(action_button->rect().bottomRight());
                 alt_widget->move(p);
                 alt_widget->show();
@@ -97,7 +97,7 @@ void ListContainer::handleNewAC(QString ac_id) {
 
             });
         connect(select_ac_button, &QObject::destroyed, action_button,
-                [=]() {
+                [=,this]() {
             action_button->deleteLater();
         });
     }
@@ -107,7 +107,7 @@ void ListContainer::handleNewAC(QString ac_id) {
     buttons[select_ac_button] = ac_id;
 
     connect(select_ac_button, &QToolButton::clicked, this,
-        [=]() {
+        [=,this]() {
             emit DispatcherUi::get()->ac_selected(ac_id);
         });
 

--- a/src/widgets/map/graphics_objects/graphics_point.cpp
+++ b/src/widgets/map/graphics_objects/graphics_point.cpp
@@ -21,7 +21,7 @@ GraphicsPoint::GraphicsPoint(int size, PprzPalette palette, QObject *parent) :
     current_color = COLOR_IDLE;
 
     animation_timer->setInterval(500);
-    connect(animation_timer, &QTimer::timeout, this, [=]()
+    connect(animation_timer, &QTimer::timeout, this, [=,this]()
     {
         animation_couter += 1;
         prepareGeometryChange();

--- a/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
+++ b/src/widgets/map/gvf_trajectories/gvf_trajectory.cpp
@@ -18,7 +18,7 @@ GVF_trajectory::GVF_trajectory(QString id, QVector<int> *gvf_settings)
 
     // If you're alive, please update your map items when gvf_viewer request it 
     connect(DispatcherUi::get(), &DispatcherUi::gvf_settingUpdated, this,
-        [=](QString sender, QVector<int> *gvf_settings) {
+        [=,this](QString sender, QVector<int> *gvf_settings) {
             if(sender == ac_id) {
                 auto gvfV_settings = *gvf_settings;
 

--- a/src/widgets/map/map2d.cpp
+++ b/src/widgets/map/map2d.cpp
@@ -47,7 +47,7 @@ Map2D::Map2D(QWidget *parent) : QGraphicsView(parent),
     setTransformationAnchor(QGraphicsView::NoAnchor);
     setBackgroundBrush(QBrush(m_color_background));
 
-    connect(this, &Map2D::backgroundChanged, this, [=](QColor c) {
+    connect(this, &Map2D::backgroundChanged, this, [=,this](QColor c) {
         setBackgroundBrush(QBrush(c));
     });
 

--- a/src/widgets/map/map_items/arrow_item.cpp
+++ b/src/widgets/map/map_items/arrow_item.cpp
@@ -17,7 +17,7 @@ ArrowItem::ArrowItem(QString ac_id, double neutral_scale_zoom, QObject *parent) 
 
     scene_item = new GraphicsGroup(palette, this);
     polygon = new QGraphicsPolygonItem(scene_item);
-    connect(scene_item, &GraphicsGroup::mousePressed, this, [=](auto event) {
+    connect(scene_item, &GraphicsGroup::mousePressed, this, [=,this](auto event) {
         (void)event;
         emit centerAC();
         emit DispatcherUi::get()->ac_selected(ac_id);

--- a/src/widgets/map/map_items/circle_item.cpp
+++ b/src/widgets/map/map_items/circle_item.cpp
@@ -44,14 +44,14 @@ void CircleItem::init(WaypointItem* center) {
     // dependence over center: if center changed, so do the CircleItem.
     connect(
         center, &WaypointItem::itemChanged, this,
-        [=]() {
+        [=,this]() {
             emit itemChanged();
         }
     );
 
     connect(
         circle, &GraphicsCircle::objectClicked, this,
-        [=](QPointF scene_pos) {
+        [=,this](QPointF scene_pos) {
             emit itemClicked(scene_pos);
             // qDebug() << "circle clicked at " << scene_pos;
         }
@@ -59,7 +59,7 @@ void CircleItem::init(WaypointItem* center) {
 
     connect(
         circle, &GraphicsCircle::objectGainedHighlight, this,
-        [=]() {
+        [=,this]() {
             setHighlighted(true);
             emit itemGainedHighlight();
         }
@@ -67,7 +67,7 @@ void CircleItem::init(WaypointItem* center) {
 
     connect(
         center, &MapItem::itemGainedHighlight, this,
-        [=]() {
+        [=,this]() {
             setHighlighted(true);
             emit itemGainedHighlight();
         }
@@ -80,7 +80,7 @@ void CircleItem::addToMap(MapWidget* map) {
 
     connect(
         circle, &GraphicsCircle::circleScaled, this,
-        [=](qreal size) {
+        [=,this](qreal size) {
             _radius = distTile2Meters(circle->pos().y()/map->tileSize(), size/map->tileSize(), zoomLevel(map->zoom()));
             circle->setText(QString::number(static_cast<int>(_radius)) + "m");
             emit circleScaled(_radius);

--- a/src/widgets/map/map_items/path_item.cpp
+++ b/src/widgets/map/map_items/path_item.cpp
@@ -50,7 +50,7 @@ void PathItem::addPoint(WaypointItem* wp, QColor line_color, bool own) {
 
     connect(
         wp, &WaypointItem::itemChanged, this,
-        [=]() {
+        [=,this]() {
             emit itemChanged();
         }
     );

--- a/src/widgets/map/map_items/waypoint_item.cpp
+++ b/src/widgets/map/map_items/waypoint_item.cpp
@@ -52,21 +52,21 @@ void WaypointItem::init() {
 
     connect(
         point, &GraphicsPoint::objectClicked, this,
-        [=](QPointF scene_pos) {
+        [=,this](QPointF scene_pos) {
             emit itemClicked(scene_pos);
         }
     );
 
     connect(
         point, &GraphicsPoint::objectDoubleClicked, this,
-        [=](QPointF scene_pos) {
+        [=,this](QPointF scene_pos) {
             emit itemDoubleClicked(scene_pos);
         }
     );
 
     connect(
         point, &GraphicsPoint::objectGainedHighlight, this,
-        [=]() {
+        [=,this]() {
             setHighlighted(true);
             emit itemGainedHighlight();
         }
@@ -79,7 +79,7 @@ void WaypointItem::addToMap(MapWidget* map) {
 
     connect(
         point, &GraphicsPoint::pointMoved, this,
-        [=](QPointF scene_pos) {
+        [=,this](QPointF scene_pos) {
             moving = true;
             // reverse position: from scene (mouse) to WGS84.
             Point2DLatLon latlon = CoordinatesTransform::get()->wgs84_from_scene(scene_pos, zoomLevel(map->zoom()), map->tileSize());
@@ -89,7 +89,7 @@ void WaypointItem::addToMap(MapWidget* map) {
 
     connect(
         point, &GraphicsPoint::pointMoveFinished, this,
-        [=](QPointF scene_pos) {
+        [=,this](QPointF scene_pos) {
             Point2DLatLon latlon = CoordinatesTransform::get()->wgs84_from_scene(scene_pos, zoomLevel(map->zoom()), map->tileSize());
             this->setPosition(latlon);
             emit waypointMoveFinished();

--- a/src/widgets/map/maplayercontrol.cpp
+++ b/src/widgets/map/maplayercontrol.cpp
@@ -34,7 +34,7 @@ MapLayerControl::MapLayerControl(QString name, QPixmap pixmap, bool initialState
     image_layout->setAlignment(show_button, Qt::AlignHCenter);
     connect(
         show_button, &QPushButton::clicked,
-        [=]() {
+        [=,this]() {
             toggleShowState();
         });
 
@@ -44,7 +44,7 @@ MapLayerControl::MapLayerControl(QString name, QPixmap pixmap, bool initialState
 
     connect(
         opacitySlider, &QSlider::valueChanged,
-        [=](int value) {
+        [=,this](int value) {
             (void) value;
             emit layerOpacityChanged(opacity());
         });

--- a/src/widgets/map/mapwidget.cpp
+++ b/src/widgets/map/mapwidget.cpp
@@ -87,7 +87,7 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
     }
 
     timer_intruders = new QTimer(this);
-    connect(timer_intruders, &QTimer::timeout, this, [=]() {
+    connect(timer_intruders, &QTimer::timeout, this, [=,this]() {
         auto now = QTime::currentTime();
         auto it = QMutableMapIterator(intruders);
         while(it.hasNext()) {
@@ -101,7 +101,7 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
     timer_intruders->start(1000);
 
     connect(scene(), &MapScene::eventScene, this,
-        [=](SmEditEvent eventType, QGraphicsSceneMouseEvent *mouseEvent) {
+        [=,this](SmEditEvent eventType, QGraphicsSceneMouseEvent *mouseEvent) {
             if(interaction_state == PMIS_FLIGHT_PLAN_EDIT && fp_edit_sm != nullptr) {
                 MapItem* item = fp_edit_sm->update(eventType, mouseEvent, nullptr, current_ac);
                 (void)item; //put item in a list relative to the drone (in a drone FP, in a block)
@@ -113,7 +113,7 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
     mapMenu = new QMenu("Map", pprzApp()->mainWindow());
 
     auto copy_coordinates = mapMenu->addAction("Copy coordinates");
-    connect(copy_coordinates, &QAction::triggered, this, [=](){
+    connect(copy_coordinates, &QAction::triggered, this, [=,this](){
         auto mc = getMouseCoords();
         auto clipboard = QApplication::clipboard();
         auto mc_txt = QString("%1, %2").arg(mc.lat(), 0, 'f', 7).arg(mc.lon(), 0, 'f', 7);
@@ -122,23 +122,23 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
 
     show_hidden_wp_action = mapMenu->addAction("Show hidden waypoints");
     show_hidden_wp_action->setCheckable(true);
-    connect(show_hidden_wp_action, &QAction::toggled, [=](bool show) {
+    connect(show_hidden_wp_action, &QAction::toggled, [=,this](bool show) {
         setProperty("show_hidden_waypoints", show);
     });
 
     show_crash_prediction_action = mapMenu->addAction("Show crash prediction");
     show_crash_prediction_action->setCheckable(true);
-    connect(show_crash_prediction_action, &QAction::toggled, [=](bool show) {
+    connect(show_crash_prediction_action, &QAction::toggled, [=,this](bool show) {
         setProperty("show_crash_prediction", show);
     });
 
     auto clear_shapes = mapMenu->addAction("Clear Shapes");
-    connect(clear_shapes, &QAction::triggered, this, [=](){
+    connect(clear_shapes, &QAction::triggered, this, [=,this](){
         clearShapes();
     });
 
     auto clear_dcshots = mapMenu->addAction("Clear DCSHOTS");
-    connect(clear_dcshots, &QAction::triggered, this, [=](){
+    connect(clear_dcshots, &QAction::triggered, this, [=,this](){
         clearDcShots();
     });
 
@@ -148,42 +148,42 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
     // Shortkeys
     auto rotate_map = new QAction(this);
     rotate_map->setShortcut(Qt::Key_R);
-    connect(rotate_map, &QAction::triggered, this, [=](){
+    connect(rotate_map, &QAction::triggered, this, [=,this](){
         rotateMap(10);
     });
     this->addAction(rotate_map);
 
     auto rotate_map_alt = new QAction(this);
     rotate_map_alt->setShortcut(QKeySequence(Qt::Key_R | Qt::ALT));
-    connect(rotate_map_alt, &QAction::triggered, this, [=](){
+    connect(rotate_map_alt, &QAction::triggered, this, [=,this](){
         rotateMap(-getRotation());
     });
     this->addAction(rotate_map_alt);
 
     auto rotate_map_ctrl = new QAction(this);
     rotate_map_ctrl->setShortcut(QKeySequence(Qt::Key_R | Qt::CTRL));
-    connect(rotate_map_ctrl, &QAction::triggered, this, [=](){
+    connect(rotate_map_ctrl, &QAction::triggered, this, [=,this](){
         rotateMap(-10);
     });
     this->addAction(rotate_map_ctrl);
 
     auto rotate_map_shift = new QAction(this);
     rotate_map_shift->setShortcut(QKeySequence(Qt::Key_R | Qt::SHIFT));
-    connect(rotate_map_shift, &QAction::triggered, this, [=](){
+    connect(rotate_map_shift, &QAction::triggered, this, [=,this](){
         rotateMap(5);
     });
     this->addAction(rotate_map_shift);
 
     auto rotate_map_ctrl_shift = new QAction(this);
     rotate_map_ctrl_shift->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_R));
-    connect(rotate_map_ctrl_shift, &QAction::triggered, this, [=](){
+    connect(rotate_map_ctrl_shift, &QAction::triggered, this, [=,this](){
         rotateMap(-5);
     });
     this->addAction(rotate_map_ctrl_shift);
 
     auto flight_plan_edit = new QAction(this);
     flight_plan_edit->setShortcut(Qt::Key_Space);
-    connect(flight_plan_edit, &QAction::triggered, this, [=](){
+    connect(flight_plan_edit, &QAction::triggered, this, [=,this](){
         interaction_state = PMIS_FLIGHT_PLAN_EDIT;
         setEditorMode();
         switch (drawState) {
@@ -196,7 +196,7 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
 
     auto freeze = new QAction(this);
     freeze->setShortcut(Qt::Key_F);
-    connect(freeze, &QAction::triggered, this, [=](){
+    connect(freeze, &QAction::triggered, this, [=,this](){
         interaction_state = PMIS_FROZEN;
         setEditorMode();
     });
@@ -204,7 +204,7 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
 
     auto center = new QAction(this);
     center->setShortcut(Qt::Key_C);
-    connect(center, &QAction::triggered, this, [=](){
+    connect(center, &QAction::triggered, this, [=,this](){
         if(AircraftManager::get()->aircraftExists(current_ac)) {
             auto ac = AircraftManager::get()->getAircraft(current_ac);
             auto orig = ac->getFlightPlan()->getOrigin();
@@ -220,14 +220,14 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
 
     auto highlight = new QAction(this);
     highlight->setShortcut(Qt::Key_H);
-    connect(highlight, &QAction::triggered, this, [=](){
+    connect(highlight, &QAction::triggered, this, [=,this](){
         itemsForbidHighlight(false);
     });
     this->addAction(highlight);
 
     auto escape = new QAction(this);
     escape->setShortcut(Qt::Key_Escape);
-    connect(escape, &QAction::triggered, this, [=](){
+    connect(escape, &QAction::triggered, this, [=,this](){
         if(interaction_state == PMIS_FLIGHT_PLAN_EDIT && fp_edit_sm != nullptr) {
             MapItem* item = fp_edit_sm->update(FPEE_CANCEL, nullptr, nullptr, current_ac);
             (void)item; //put item in a list relative to the drone (in a drone FP, in a block)
@@ -246,14 +246,14 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
     connect(AircraftManager::get(), &AircraftManager::waypoint_added, this, &MapWidget::onWaypointAdded);
     connect(DispatcherUi::get(), &DispatcherUi::move_waypoint_ui, this, &MapWidget::onMoveWaypointUi);
     connect(DispatcherUi::get(), &DispatcherUi::slamGridVisibilityChanged, this,
-        [=](bool visible) {
+        [=,this](bool visible) {
             if(grid_item) {
                 grid_item->setVisible(visible);
                 
             }
         });
     connect(DispatcherUi::get(), &DispatcherUi::obstacleVisibilityChanged, this,
-        [=](bool visible) {
+        [=,this](bool visible) {
             obstacles_visible = visible;
             if(!visible) {
                 for(auto& pair : slam_obstacles) {
@@ -264,7 +264,7 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
             }
         });
     connect(DispatcherUi::get(), &DispatcherUi::gvf_settingUpdated, this,
-        [=](QString sender, QVector<int>* gvfViewer_config) {
+        [=,this](QString sender, QVector<int>* gvfViewer_config) {
             gvf_trajectories_config.remove(sender);
             gvf_trajectories_config[sender] = gvfViewer_config;
         });
@@ -280,22 +280,22 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
 
 
     shape_bind_id = PprzDispatcher::get()->bind("SHAPE", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onShape(sender, msg);
         });
 
     PprzDispatcher::get()->bind("INTRUDER", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onIntruder(sender, msg);
         });
 
     PprzDispatcher::get()->bind("DC_SHOT", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onDcShot(sender, msg);
         });
 
     PprzDispatcher::get()->bind("FLIGHT_PARAM", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             (void)sender;
             QString id;
             msg.getField("ac_id", id);
@@ -312,39 +312,39 @@ MapWidget::MapWidget(QWidget *parent) : Map2D(parent),
         });
 
     PprzDispatcher::get()->bind("GVF", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onGVF(sender, msg);
         });
 
     PprzDispatcher::get()->bind("GVF_PARAMETRIC", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onGVF(sender, msg);
         });
 
     PprzDispatcher::get()->bind("ROTORCRAFT_FP", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onROTORCRAFT_FP(sender, msg);
         });
 
     PprzDispatcher::get()->bind("SLAM", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onSLAM(sender, msg);
         });
 
     PprzDispatcher::get()->bind("GRID_INIT", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onGridInit(sender, msg);
         });
 
     PprzDispatcher::get()->bind("GRID_CHANGES", this,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             onGridChanges(sender, msg);
         });
 
     setAcceptDrops(true);
 
     // Add menu to app menu bar.
-    connect(pprzApp()->mainWindow(), &PprzMain::ready, this, [=](){
+    connect(pprzApp()->mainWindow(), &PprzMain::ready, this, [=,this](){
         auto actions = pprzApp()->mainWindow()->menuBar()->actions();
         int index = actions.size()-1;
         if(index < 0) {
@@ -380,7 +380,7 @@ void MapWidget::changeCurrentAC(QString id) {
 
 void MapWidget::registerWaypoint(WaypointItem* waypoint) {
     connect(waypoint, &WaypointItem::itemClicked, this,
-        [=](QPointF pos) {
+        [=,this](QPointF pos) {
             (void)pos;
             if(interaction_state == PMIS_FLIGHT_PLAN_EDIT && fp_edit_sm != nullptr) {
                 MapItem* item = fp_edit_sm->update(FPEE_WP_CLICKED, nullptr, waypoint, current_ac);
@@ -404,7 +404,7 @@ LayerCombo* MapWidget::makeLayerCombo() {
 
     connect(
         layer_combo, &LayerCombo::showLayer, this,
-        [=](QString name, bool state) {
+        [=,this](QString name, bool state) {
             toggleTileProvider(name, state);
             updateTiles();
         }
@@ -412,14 +412,14 @@ LayerCombo* MapWidget::makeLayerCombo() {
 
     connect(
         layer_combo, &LayerCombo::layerOpacityChanged, this,
-        [=](QString name, qreal opacity) {
+        [=,this](QString name, qreal opacity) {
             setLayerOpacity(name, opacity);
         }
     );
 
     connect(
         layer_combo, &LayerCombo::zValueChanged, this,
-        [=](QString name, int z) {
+        [=,this](QString name, int z) {
             setLayerZ(name, z);
         }
     );
@@ -452,7 +452,7 @@ void MapWidget::addWidget(QWidget* widget, LockButton* button, WidgetContainer s
 
     connect(
         button, &LockButton::clicked,
-        [=](bool active) {
+        [=,this](bool active) {
             for(auto lb: *buttons) {
                 if(lb != button) {  //other buttons
                     if(!lb->isLocked()) {
@@ -524,7 +524,7 @@ void MapWidget::configure(QDomElement ele) {
     wind_indicator->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     rightLayout->addWidget(wind_indicator, 0, Qt::AlignRight);
 
-    PprzDispatcher::get()->bind("WIND", this, [=](QString sender, pprzlink::Message msg){
+    PprzDispatcher::get()->bind("WIND", this, [=,this](QString sender, pprzlink::Message msg){
         (void)sender;
         QString ac_id;
         msg.getField("ac_id", ac_id);
@@ -535,7 +535,7 @@ void MapWidget::configure(QDomElement ele) {
         wind_indicator->setWindData(ac_id, dir, wspeed);
     });
 
-    connect(wind_indicator, &WindIndicator::requestRotation, this, [=](double rot) {
+    connect(wind_indicator, &WindIndicator::requestRotation, this, [=,this](double rot) {
         rotateMap(rot-getRotation());
     });
 
@@ -560,11 +560,11 @@ void MapWidget::addItem(MapItem* map_item) {
         registerWaypoint(wi);
     }
 
-    connect(map_item, &MapItem::itemChanged, map_item, [=]() {
+    connect(map_item, &MapItem::itemChanged, map_item, [=,this]() {
         map_item->updateGraphics(this, UpdateEvent::ITEM_CHANGED);
     });
 
-    connect(map_item, &MapItem::itemGainedHighlight, map_item, [=]() {
+    connect(map_item, &MapItem::itemGainedHighlight, map_item, [=,this]() {
         QString ac_id = map_item->acId();
         if(ac_id != "__NO_AC__") {
             emit DispatcherUi::get()->ac_selected(ac_id);
@@ -682,7 +682,7 @@ bool MapWidget::viewportEvent(QEvent *event) {
     case QEvent::TouchEnd:
     {
         QTouchEvent *touchEvent = static_cast<QTouchEvent *>(event);
-        QList<QTouchEvent::TouchPoint> touchPoints = touchEvent->touchPoints();
+        QList<QEventPoint> touchPoints = touchEvent->points();
 
         for(auto &touchPoint: touchPoints) {
             if(touchPoint.state() == QEventPoint::State::Pressed) {
@@ -818,7 +818,7 @@ void MapWidget::dropEvent(QDropEvent *event) {
         papget->setZValue(1000);
         papgets.append(papget);
 
-        connect(papget, &Papget::moved, this, [=](QPointF pos) {
+        connect(papget, &Papget::moved, this, [=,this](QPointF pos) {
             QPoint viewPos = mapFromScene(pos);
             papget->setPosition(viewPos);
         });
@@ -862,7 +862,7 @@ void MapWidget::handleNewAC(QString ac_id) {
         addItem(arrow);
         arrow->setProperty("size", _ac_arrow_size);
 
-        connect(arrow, &ArrowItem::centerAC, this, [=]() {
+        connect(arrow, &ArrowItem::centerAC, this, [=,this]() {
             auto pos = ac->getPosition();
             centerLatLon(pos);
         });
@@ -871,7 +871,7 @@ void MapWidget::handleNewAC(QString ac_id) {
         item_manager = new ACItemManager(ac_id, target, aircraft_item, arrow, crash_item, this);
 
         auto clear_track = new QAction(ac->name(), ac);
-        connect(clear_track, &QAction::triggered, aircraft_item, [=](){
+        connect(clear_track, &QAction::triggered, aircraft_item, [=,this](){
             aircraft_item->clearTrack();
         });
         menu_clear_track->addAction(clear_track);
@@ -938,14 +938,14 @@ void MapWidget::onWaypointAdded(Waypoint* wp, QString ac_id) {
     addItem(wpi);
     ac_items_managers[ac_id]->addWaypointItem(wpi);
 
-    auto dialog_move_waypoint = [=]() {
+    auto dialog_move_waypoint = [=,this]() {
         wpi->setMoving(true);
         auto we = new WaypointEditor(wpi, ac_id);
         auto view_pos = mapFromScene(wpi->scenePos());
         auto global_pos = mapToGlobal(view_pos);
         we->show(); //show just to get the width and height right.
         we->move(global_pos - QPoint(we->width()/2, we->height()/2));
-        connect(we, &QDialog::finished, wpi, [=](int result) {
+        connect(we, &QDialog::finished, wpi, [=,this](int result) {
             (void)result;
             wpi->setMoving(false);
             if(!result) {
@@ -960,7 +960,7 @@ void MapWidget::onWaypointAdded(Waypoint* wp, QString ac_id) {
 
     connect(wpi, &WaypointItem::itemDoubleClicked, this, dialog_move_waypoint);
 
-    connect(wpi, &WaypointItem::waypointMoved, this, [=](){
+    connect(wpi, &WaypointItem::waypointMoved, this, [=,this](){
         wpi->setAnimate(true);
     });
 
@@ -1010,7 +1010,7 @@ void MapWidget::updateNavShape(pprzlink::Message msg) {
 
     MapItem* prev_item = ac_items_managers[ac_id]->getCurrentNavShape();
 
-    auto delete_prev = [=]() {
+    auto delete_prev = [=,this]() {
         if(prev_item != nullptr) {
             // prev_item not null, delete it
             ac_items_managers[ac_id]->setCurrentNavShape(nullptr);

--- a/src/widgets/map/papget.cpp
+++ b/src/widgets/map/papget.cpp
@@ -22,11 +22,11 @@ Papget::Papget(struct DataDef datadef, QPoint pos_view, QObject *parent) : QObje
     data_scale = datadef.scale;
 
     bindRet = PprzDispatcher::get()->bind(datadef.msg_name,
-        [=](QString sender, pprzlink::Message msg) {
+        [=,this](QString sender, pprzlink::Message msg) {
             QTimer* timer = new QTimer();
             timer->moveToThread(qApp->thread());
             timer->setSingleShot(true);
-            QObject::connect(timer, &QTimer::timeout, this, [=]()
+            QObject::connect(timer, &QTimer::timeout, this, [=,this]()
             {
                 // main thread
                 callback(sender, msg);
@@ -151,11 +151,11 @@ void Papget::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) {
     Params old_params = params;
     auto pc = new PapgetConfig(datadef, params);
 
-    connect(pc, &PapgetConfig::paramsChanged, this, [=](Params new_params) mutable {
+    connect(pc, &PapgetConfig::paramsChanged, this, [=,this](Params new_params) mutable {
             params = new_params;
     });
 
-    connect(pc, &QDialog::finished, this, [=](int result) mutable {
+    connect(pc, &QDialog::finished, this, [=,this](int result) mutable {
         if(!result) {
             params = old_params;
         }

--- a/src/widgets/map/papgetconfig.cpp
+++ b/src/widgets/map/papgetconfig.cpp
@@ -18,7 +18,7 @@ PapgetConfig::PapgetConfig(Papget::DataDef datadef, Papget::Params params, QWidg
     callbacks.append(cb);
     stack->addWidget(text_widget);
 
-    connect(comboStyle, qOverload<int>(&QComboBox::currentIndexChanged), this, [=](int index) {
+    connect(comboStyle, qOverload<int>(&QComboBox::currentIndexChanged), this, [=,this](int index) {
         stack->setCurrentIndex(index);
         callbacks[index]();
     });
@@ -27,13 +27,13 @@ PapgetConfig::PapgetConfig(Papget::DataDef datadef, Papget::Params params, QWidg
     auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     lay->addWidget(buttonBox);
 
-    connect(buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, [=]() mutable {
+    connect(buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, [=,this]() mutable {
 
         emit paramsChanged(this->params);
         accept();
     });
 
-    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, [=](){
+    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, [=,this](){
         reject();
     });
 }
@@ -56,12 +56,12 @@ std::function<void()> PapgetConfig::config_text(QWidget* w) {
     combo_color->addItems(colors);
     layout->addLayout(color_layout);
 
-    connect(size_sp, qOverload<int>(&QSpinBox::valueChanged), [=](int val) {
+    connect(size_sp, qOverload<int>(&QSpinBox::valueChanged), [=,this](int val) {
         params.fontSize = val;
         emit paramsChanged(params);
     });
 
-    connect(combo_color, &QComboBox::currentTextChanged, this, [=](QString text) {
+    connect(combo_color, &QComboBox::currentTextChanged, this, [=,this](QString text) {
         if(text == "AC color" || text == ""){
             auto ac = AircraftManager::get()->getAircraft(datadef.ac_id);
             params.color = ac->getColor();
@@ -71,7 +71,7 @@ std::function<void()> PapgetConfig::config_text(QWidget* w) {
         emit paramsChanged(params);
     });
 
-    auto val = [=]() mutable {
+    auto val = [=,this]() mutable {
         params.fontSize = size_sp->value();
         params.style = Papget::Style::TEXT;
     };

--- a/src/widgets/map/tileprovider.cpp
+++ b/src/widgets/map/tileprovider.cpp
@@ -31,7 +31,7 @@ TileProvider::~TileProvider() {
 }
 
 void TileProvider::removeFromScene(QGraphicsScene* scene) {
-    tileApplyRecursive(motherTile, [=](TileItem* tile) {
+    tileApplyRecursive(motherTile, [=,this](TileItem* tile) {
         if(tile->isInScene()) {
             scene->removeItem(tile);
             tile->setInScene(false);
@@ -257,7 +257,7 @@ void TileProvider::sendTile(TileItem* tileReady, TileItem* tileObj) {
 
 void TileProvider::setZoomLevel(int z) {
 
-    tileApplyRecursive(motherTile, [=](TileItem* tile) {
+    tileApplyRecursive(motherTile, [=,this](TileItem* tile) {
         if(tile->hasData() && tile->coordinates().zoom() != z) {
             tile->hide();
         }
@@ -303,7 +303,7 @@ void TileProvider::setZValue(int z) {
     //iterate over all items in scene
 
 
-    tileApplyRecursive(motherTile, [=](TileItem* tile) {
+    tileApplyRecursive(motherTile, [=,this](TileItem* tile) {
         if(tile->isInScene()) {
             tile->setZValue(z);
         }
@@ -313,7 +313,7 @@ void TileProvider::setZValue(int z) {
 void TileProvider::setOpacity(qreal a) {
     alpha = a;
 
-    tileApplyRecursive(motherTile, [=](TileItem* tile) {
+    tileApplyRecursive(motherTile, [=,this](TileItem* tile) {
         if(tile->isInScene()) {
             tile->setOpacity(alpha);
         }
@@ -326,7 +326,7 @@ void TileProvider::setVisible(bool v) {
     }
     visibility = v;
 
-    tileApplyRecursive(motherTile, [=](TileItem* tile) {
+    tileApplyRecursive(motherTile, [=,this](TileItem* tile) {
         if(tile->isInScene()) {
             tile->setVisible(visibility);
         }

--- a/src/widgets/map/waypointeditor.cpp
+++ b/src/widgets/map/waypointeditor.cpp
@@ -64,7 +64,7 @@ WaypointEditor::WaypointEditor(WaypointItem* wi, QString ac_id, QWidget *parent)
     infoLay->addLayout(altLay);
     infoLay->addLayout(butLay);
 
-    auto updateAgl = [=]() {
+    auto updateAgl = [=,this]() {
         auto ele = SRTMManager::get()->get_elevation(wi->waypoint()->getLat(), wi->waypoint()->getLon());
         double agl;
         if(ele) {
@@ -81,7 +81,7 @@ WaypointEditor::WaypointEditor(WaypointItem* wi, QString ac_id, QWidget *parent)
 
     updateAgl();
 
-    auto updateLatLon = [=]() {
+    auto updateLatLon = [=,this]() {
         bool ok_a = false;
         bool ok_b = false;
         double a = latEdit->text().toDouble(&ok_a);
@@ -114,36 +114,36 @@ WaypointEditor::WaypointEditor(WaypointItem* wi, QString ac_id, QWidget *parent)
         }
     };
 
-    connect(latEdit, &QLineEdit::textEdited, [=](){
+    connect(latEdit, &QLineEdit::textEdited, [=,this](){
         updateLatLon();
         updateAgl();
     });
 
-    connect(lonEdit, &QLineEdit::textEdited, [=](){
+    connect(lonEdit, &QLineEdit::textEdited, [=,this](){
         updateLatLon();
         updateAgl();
     });
 
 
-    connect(altSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), [=](double alt){
+    connect(altSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), [=,this](double alt){
         wi->waypoint()->setAlt(alt);
         updateAgl();
     });
 
-    connect(upButton, &QAbstractButton::clicked, [=]() {
+    connect(upButton, &QAbstractButton::clicked, [=,this]() {
         wi->waypoint()->setAlt(wi->waypoint()->getAlt() + 10);
         altSpin->setValue(wi->waypoint()->getAlt());
         updateAgl();
     });
 
-    connect(downButton, &QAbstractButton::clicked, [=]() {
+    connect(downButton, &QAbstractButton::clicked, [=,this]() {
         wi->waypoint()->setAlt(wi->waypoint()->getAlt() - 10);
         altSpin->setValue(wi->waypoint()->getAlt());
         updateAgl();
     });
 
 
-    connect(combo, &QComboBox::currentTextChanged, this, [=](const QString &text) {
+    connect(combo, &QComboBox::currentTextChanged, this, [=,this](const QString &text) {
         if(text == WGS84) {
             axis1_label->setText("lat");
             axis2_label->setText("lon");
@@ -185,13 +185,13 @@ WaypointEditor::WaypointEditor(WaypointItem* wi, QString ac_id, QWidget *parent)
     auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     lay->addWidget(buttonBox);
 
-    connect(buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, [=](){
+    connect(buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, [=,this](){
         emit DispatcherUi::get()->move_waypoint_ui(wi->waypoint(), ac_id);
         accept();
 
     });
 
-    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, [=](){
+    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, [=,this](){
         reject();
     });
 }

--- a/src/widgets/mini_strip.cpp
+++ b/src/widgets/mini_strip.cpp
@@ -51,7 +51,7 @@ MiniStrip::MiniStrip(QString ac_id, QWidget *parent) : QWidget(parent),
     alt_layout->addWidget(alt_label);
     gl->addLayout(alt_layout, 1, 1);
     connect(alt_button, &QToolButton::clicked, this,
-        [=]() {
+        [=,this]() {
             alt_mode = !alt_mode;
             if(alt_mode) {
                 alt_button->setIcon(agl_icon);
@@ -79,7 +79,7 @@ MiniStrip::MiniStrip(QString ac_id, QWidget *parent) : QWidget(parent),
     ft_lay->addStretch();
     gl->addLayout(ft_lay, 0, 1);
     connect(time_button, &QToolButton::clicked, this,
-        [=]() {
+        [=,this]() {
         switch (time_mode) {
         case FLIGHT_TIME:
             time_mode = BLOCK_TIME;
@@ -118,7 +118,7 @@ MiniStrip::MiniStrip(QString ac_id, QWidget *parent) : QWidget(parent),
     speed_lay->addWidget(speed_label);
     gl->addLayout(speed_lay, 2, 1);
     connect(speed_button, &QToolButton::clicked, this,
-        [=]() {
+        [=,this]() {
             switch (speed_mode) {
             case GROUND_SPEED:
                 speed_mode = AIR_SPEED;
@@ -189,7 +189,7 @@ MiniStrip::MiniStrip(QString ac_id, QWidget *parent) : QWidget(parent),
     auto settings = ac->getSettingMenu()->getAllSettings();
     for(auto setting: settings) {
         if(setting->getName() == "autopilot.mode") {
-            connect(ap_mode_button, &QPushButton::clicked, this, [=](){
+            connect(ap_mode_button, &QPushButton::clicked, this, [=,this](){
                 AircraftManager::get()->getAircraft(ac_id)->setSetting(setting, "AUTO2");
             });
             break;

--- a/src/widgets/plotter.cpp
+++ b/src/widgets/plotter.cpp
@@ -19,7 +19,7 @@ Plotter::Plotter(QString ac_id, QWidget *parent) : QWidget(parent),
 
     autoscale_checkbox = new QCheckBox("autoscale", this);
     top_lay->addWidget(autoscale_checkbox);
-    connect(autoscale_checkbox, &QCheckBox::stateChanged, this, [=](int state) {
+    connect(autoscale_checkbox, &QCheckBox::stateChanged, this, [=,this](int state) {
         if(graphs.contains(current_name)) {
             auto p = graphs[current_name]->getParams();
             p.autoscale = state;
@@ -31,7 +31,7 @@ Plotter::Plotter(QString ac_id, QWidget *parent) : QWidget(parent),
     top_lay->addWidget(history_spinbox);
     history_spinbox->setRange(1, 999);
     history_spinbox->setToolTip("history (s)");
-    connect(history_spinbox, qOverload<int>(&QSpinBox::valueChanged), this, [=](int value) {
+    connect(history_spinbox, qOverload<int>(&QSpinBox::valueChanged), this, [=,this](int value) {
         if(graphs.contains(current_name)) {
             graphs[current_name]->setHistory(value * 1000);
         }
@@ -51,7 +51,7 @@ Plotter::Plotter(QString ac_id, QWidget *parent) : QWidget(parent),
     lay->setStretch(1, 1);
 
     connect(var_button, &QToolButton::clicked, this, &Plotter::onOpenContextMenu);
-    connect(close_button, &QToolButton::clicked, this, [=]() {removeGraph(current_name);});
+    connect(close_button, &QToolButton::clicked, this, [=,this]() {removeGraph(current_name);});
 
 
     setAcceptDrops(true);
@@ -98,7 +98,7 @@ void Plotter::addGraph(QString name, GraphWidget::Params p) {
     auto def = name.split(":");
 
     bids[name] = PprzDispatcher::get()->bind(def[1], this,
-        [=](QString sender, pprzlink::Message msg){
+        [=,this](QString sender, pprzlink::Message msg){
             handleMsg(name, sender, msg);
         });
 
@@ -108,7 +108,7 @@ void Plotter::addGraph(QString name, GraphWidget::Params p) {
         current_name = name;
     }
 
-    connect(graph, &GraphWidget::autoscaleChanged, this, [=](bool a){
+    connect(graph, &GraphWidget::autoscaleChanged, this, [=,this](bool a){
         if(graph == graphs[current_name]) {
             autoscale_checkbox->setChecked(a);
         }
@@ -149,7 +149,7 @@ void Plotter::onOpenContextMenu() {
 
     for(auto gr=graphs.begin(); gr!=graphs.end(); ++gr) {
         auto action = menu->addAction(gr.key());
-        connect(action, &QAction::triggered, this, [=]() {
+        connect(action, &QAction::triggered, this, [=,this]() {
             changeGraph(gr.key());
         });
     }
@@ -162,7 +162,7 @@ void Plotter::onOpenContextMenu() {
         for(size_t i=0; i < def.getNbFields(); ++i) {
             auto f = def.getField(static_cast<int>(i));
             auto f_action = msg_menu->addAction(f.getName());
-            connect(f_action, &QAction::triggered, this, [=]() {
+            connect(f_action, &QAction::triggered, this, [=,this]() {
                 auto name = "ground:" +  def.getName() + ":" + f.getName();
                 // FIXME scale at 1.0 ???
                 addGraph(name, {100, 0, true, 1.0});

--- a/src/widgets/pprzmap.cpp
+++ b/src/widgets/pprzmap.cpp
@@ -21,7 +21,7 @@ PprzMap::PprzMap(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    auto dl_strm = [=](bool local_only) {
+    auto dl_strm = [=,this](bool local_only) {
 
         QSet<QString> tiles;
 
@@ -51,16 +51,16 @@ PprzMap::PprzMap(QWidget *parent) :
 
     };
 
-    connect(ui->srtm_button, &QPushButton::clicked, [=]() {dl_strm(false);});
+    connect(ui->srtm_button, &QPushButton::clicked, [=,this]() {dl_strm(false);});
 #if GRPC_ENABLED
-    connect(GRPCConnector::get(), &GRPCConnector::dl_srtm, [=]() {dl_strm(true);});
+    connect(GRPCConnector::get(), &GRPCConnector::dl_srtm, [=,this]() {dl_strm(true);});
 #endif
 
     connect(DispatcherUi::get(), &DispatcherUi::ac_selected, this, &PprzMap::changeCurrentAC);
     connect(ui->map, &MapWidget::mouseMoved, this, &PprzMap::handleMouseMove);
 
     connect(AircraftManager::get(), &AircraftManager::waypoint_changed, this,
-            [=](Waypoint* wp, QString ac_id) {
+            [=,this](Waypoint* wp, QString ac_id) {
         (void)wp;
         if(current_ac == ac_id) {
             if(combo_indexes.contains(wp)) {
@@ -69,7 +69,7 @@ PprzMap::PprzMap(QWidget *parent) :
         }
     });
     connect(AircraftManager::get(), &AircraftManager::waypoint_added, this,
-            [=](Waypoint* wp, QString ac_id) {
+            [=,this](Waypoint* wp, QString ac_id) {
         (void)wp;
         if(current_ac == ac_id) {
             changeCurrentAC(ac_id);

--- a/src/widgets/settings_viewer.cpp
+++ b/src/widgets/settings_viewer.cpp
@@ -47,7 +47,7 @@ SettingsViewer::SettingsViewer(QString ac_id, QWidget *parent) : QWidget(parent)
     search_bar->setClearButtonEnabled(true);
     search_layout->addWidget(search_bar);
 
-    auto search_callback = [=](const QString str) {
+    auto search_callback = [=,this](const QString str) {
         if(str == "") {
             restore_searched_items();
             scroll_content->setCurrentIndex(last_widget_index);
@@ -66,7 +66,7 @@ SettingsViewer::SettingsViewer(QString ac_id, QWidget *parent) : QWidget(parent)
 
     connect(
         search_bar, &QLineEdit::returnPressed,
-        [=]() {
+        [=,this]() {
             auto str = search_bar->text();
             search_callback(str);
     }
@@ -109,7 +109,7 @@ void SettingsViewer::init(QString ac_id) {
 
     connect(
         button_home, &QToolButton::clicked, this,
-        [=]() {
+        [=,this]() {
             scroll_content->setCurrentIndex(widgets_indexes[settings]);
             path->setCurrentIndex(path_indexes[settings]);
             scroll->verticalScrollBar()->setValue(0);
@@ -119,7 +119,7 @@ void SettingsViewer::init(QString ac_id) {
 
     connect(
         button_save, &QToolButton::clicked, this,
-        [=]() {
+        [=,this]() {
             auto saver_dialog = new SettingSaver(ac_id, this);
             saver_dialog->open();
         }
@@ -150,7 +150,7 @@ void SettingsViewer::create_widgets(SettingMenu* setting_menu, QList<SettingMenu
 
             connect(
                 button, &QPushButton::clicked, this,
-                [=]() {
+                [=,this]() {
 
                     scroll_content->setCurrentIndex(widgets_indexes[setm]);
                     path->setCurrentIndex(path_indexes[setm]);
@@ -176,7 +176,7 @@ void SettingsViewer::create_widgets(SettingMenu* setting_menu, QList<SettingMenu
         create_widgets(sets, new_stack);
         connect(
             button, &QPushButton::clicked, this,
-            [=]() {
+            [=,this]() {
                 scroll_content->setCurrentIndex(widgets_indexes[sets]);
                 path->setCurrentIndex(path_indexes[sets]);
                 restore_searched_items();
@@ -266,7 +266,7 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
     reset_btn->setToolTip("reset to initial");
     hlay->addWidget(reset_btn);
 
-    connect(value_btn, &QPushButton::clicked, this, [=]() {
+    connect(value_btn, &QPushButton::clicked, this, [=,this]() {
         value_btn->setText("?");
         pprzlink::Message getSetting(PprzDispatcher::get()->getDict()->getDefinition("GET_DL_SETTING"));
         getSetting.addField("ac_id", ac_id);
@@ -274,13 +274,13 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
         PprzDispatcher::get()->sendMessage(getSetting);
     });
 
-    connect(undo_btn, &QToolButton::clicked, this, [=]() {
+    connect(undo_btn, &QToolButton::clicked, this, [=,this]() {
         auto prev = setting->getPreviousValue();
         AircraftManager::get()->getAircraft(ac_id)->setSetting(setting, prev);
         setting->setUserValue(prev);
     });
 
-    connect(reset_btn, &QToolButton::clicked, this, [=]() {
+    connect(reset_btn, &QToolButton::clicked, this, [=,this]() {
         auto initial_value = setting->getInitialValue();
         if(initial_value.has_value()) {
             AircraftManager::get()->getAircraft(ac_id)->setSetting(setting, initial_value.value());
@@ -306,7 +306,7 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
             value_btn->setText(combo->itemText(static_cast<int>(value)));
         };
 
-        connect(ok_btn, &QToolButton::clicked, this, [=]() {
+        connect(ok_btn, &QToolButton::clicked, this, [=,this]() {
             float value = static_cast<float>(combo->currentIndex());
             AircraftManager::get()->getAircraft(ac_id)->setSetting(setting, value);
             setting->setUserValue(value);
@@ -339,7 +339,7 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
             value_btn->setText(txt);
         };
 
-        connect(ok_btn, &QToolButton::clicked, this, [=, min=min, max=max]() {
+        connect(ok_btn, &QToolButton::clicked, this, [=, this, min=min, max=max]() {
             float value = sw->isChecked() ? max : min;
             AircraftManager::get()->getAircraft(ac_id)->setSetting(setting, value);
             setting->setUserValue(value);
@@ -353,7 +353,7 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
         uniq_val->setAlignment(Qt::AlignCenter);
         vLay->addWidget(uniq_val);
 
-        connect(ok_btn, &QToolButton::clicked, this, [=]() {
+        connect(ok_btn, &QToolButton::clicked, this, [=,this]() {
             AircraftManager::get()->getAircraft(ac_id)->setSetting(setting, value);
             setting->setUserValue(value);
         });
@@ -377,12 +377,12 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
             precision = static_cast<int>(ceil(abs(log10(step))));
         }
         connect(slider, &DoubleSlider::doubleValueChanged,
-            [=](double value) {
+            [=,this](double value) {
                 la->setText(QString::number(value, 'f', precision));
             });
 
         connect(expert_button, &QToolButton::clicked,
-            [=]() {
+            [=,this]() {
                 raw_edit->setVisible(!raw_edit->isVisible());
                 if(raw_edit->isVisible()) {
                     expert_button->setIcon(QIcon(":/pictures/lock_warning.svg"));
@@ -392,7 +392,7 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
             });
 
         connect(raw_edit, &QLineEdit::returnPressed, this,
-            [=, min=min, max=max]() {
+            [=, this, min=min, max=max]() {
                 auto txt = raw_edit->text();
                 bool ok;
                 auto value = static_cast<float>(txt.toDouble(&ok));
@@ -409,7 +409,7 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
             });
 
         connect(raw_edit, &QLineEdit::textChanged,
-            [=]() {
+            [=,this]() {
                 raw_edit->setStyleSheet("QLineEdit{background-color: #ffffff;}");
             });
 
@@ -420,7 +420,7 @@ QWidget* SettingsViewer::makeSettingWidget(Setting* setting, QWidget* parent) {
         vbox->addWidget(expert_button);
         vLay->addLayout(vbox);
 
-        connect(ok_btn, &QToolButton::clicked, this, [=]() {
+        connect(ok_btn, &QToolButton::clicked, this, [=,this]() {
             auto coef = setting->getAltUnitCoef();
             float value = static_cast<float>(slider->doubleValue()) / coef;
             AircraftManager::get()->getAircraft(ac_id)->setSetting(setting, value);
@@ -505,7 +505,7 @@ SettingSaver::SettingSaver(QString ac_id, QWidget *parent) : QDialog(parent),
     lay->addWidget(all_check);
 
 
-    connect(all_check, &QCheckBox::toggled, this, [=](bool state) {
+    connect(all_check, &QCheckBox::toggled, this, [=,this](bool state) {
         for(int i=0; i < tree->topLevelItemCount(); i++) {
             auto item = tree->topLevelItem(i);
             item->setCheckState(0, state ? Qt::Checked : Qt::Unchecked);
@@ -520,7 +520,7 @@ SettingSaver::SettingSaver(QString ac_id, QWidget *parent) : QDialog(parent),
     auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel, this);
     lay->addWidget(buttonBox);
 
-    connect(buttonBox->button(QDialogButtonBox::Save), &QPushButton::clicked, this, [=](){
+    connect(buttonBox->button(QDialogButtonBox::Save), &QPushButton::clicked, this, [=,this](){
         QMap<QString, QString> changed_params;
 
         for(int i=0; i < tree->topLevelItemCount(); i++) {
@@ -562,7 +562,7 @@ SettingSaver::SettingSaver(QString ac_id, QWidget *parent) : QDialog(parent),
 
     });
 
-    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, [=](){
+    connect(buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, [=,this](){
         reject();
     });
 }

--- a/src/widgets/stackcontainer.cpp
+++ b/src/widgets/stackcontainer.cpp
@@ -27,7 +27,7 @@ StackContainer::StackContainer(std::function<QWidget*(QString, QWidget*)> constr
     connect(DispatcherUi::get(), &DispatcherUi::new_ac_config, this, &StackContainer::handleNewAC);
     connect(DispatcherUi::get(), &DispatcherUi::ac_deleted, this, &StackContainer::removeAC);
     connect(DispatcherUi::get(), &DispatcherUi::ac_selected, this,
-            [=](QString ac_id) {
+            [=,this](QString ac_id) {
                 for(auto &id : viewers_widgets.keys()) {
                     if(id == ac_id) {
                         viewers_widgets[id]->show();


### PR DESCRIPTION
Fix various warnings, first coming from a feature introduced in Cpp20, then fixing the deprecation warnings linked to this bump up.
Other warnings have been fixed in PprzlinkQt and IvyQt, and their submodules should be updated before integrating these changes.

- [ ] PprzlinkQt (and its submodule IvyQt) are updated 